### PR TITLE
Encoded Binary Register Accesses

### DIFF
--- a/include/encoded_accessor_macros.h
+++ b/include/encoded_accessor_macros.h
@@ -1,0 +1,155 @@
+//
+// Shoulder
+// Copyright (C) 2018 Assured Information Security, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+//
+
+#ifndef ENCODED_ACCESSOR_MACROS_H
+#define ENCODED_ACCESSOR_MACROS_H
+
+#ifndef GET_SYSREG
+#define GET_SYSREG(encoding, dest)                                             \
+    __asm__ __volatile__(                                                      \
+        ".word "#encoding"\n"                                                  \
+        "mov %0, x0\n"                                                         \
+        : "=r"(dest)                                                           \
+        : : "x0"                                                               \
+    )
+#endif
+
+#ifndef SET_SYSREG_BY_VALUE
+#define SET_SYSREG_BY_VALUE(encoding, val)                                     \
+    __asm__ __volatile__(                                                      \
+        "mov x0, %0\n"                                                         \
+        ".word "#encoding"\n"                                                  \
+        : : "r"(val)                                                           \
+        : "x0"                                                                 \
+    )
+#endif
+
+#ifndef GET_SYSREG_FIELD
+#define GET_SYSREG_FIELD(encoding, dest, mask, lsb)                            \
+    __asm__ __volatile__(                                                      \
+        ".word "#encoding"\n"                                                  \
+        "mov %[d], x0\n"                                                       \
+        "and %[d], %[d], %[m]\n"                                               \
+        "lsr %[d], %[d], #"#lsb"\n"                                            \
+        : [d] "+r" (dest)                                                      \
+        : [m] "r" (mask)                                                       \
+        : "x0"                                                                 \
+    )
+#endif
+
+#ifndef SET_SYSREG_BITS_BY_VALUE
+#define SET_SYSREG_BITS_BY_VALUE(get_encoding, set_encoding,                   \
+                                 new_val, old_val, mask, lsb)                  \
+    __asm__ __volatile__(                                                      \
+        "lsl %[nv], %[nv], #"#lsb"\n"                                          \
+        "and %[nv], %[nv], %[m]\n"                                             \
+        "mvn %[m], %[m]\n"                                                     \
+        ".word "#get_encoding"\n"                                              \
+        "mov %[ov], x0\n"                                                      \
+        "and %[ov], %[ov], %[m]\n"                                             \
+        "orr %[nv], %[nv], %[ov]\n"                                            \
+        "mov x0, %[nv]\n"                                                      \
+        ".word "#set_encoding"\n"                                              \
+        : [nv] "+r" (new_val), [ov] "+r" (old_val), [m] "+r" (mask)            \
+        : : "x0"                                                               \
+    )
+#endif
+
+#ifndef SET_SYSREG_BITS_BY_VALUE_FUNC
+#define SET_SYSREG_BITS_BY_VALUE_FUNC(get_encoding, set_encoding,              \
+                                      value, bitmask, lsb)                     \
+    uint64_t old_val;                                                          \
+    uint64_t new_val = value;                                                  \
+    uint64_t mask = bitmask;                                                   \
+    SET_SYSREG_BITS_BY_VALUE(get_encoding, set_encoding,                       \
+                             new_val, old_val, mask, lsb);
+#endif
+
+#ifndef IS_SYSREG_BIT_ENABLED
+#define IS_SYSREG_BIT_ENABLED(encoding, result, lsb)                           \
+    __asm__ __volatile__(                                                      \
+        ".word "#encoding"\n"                                                  \
+        "mov %[res], x0\n"                                                     \
+        "lsr %[res], %[res], #"#lsb"\n"                                        \
+        "and %[res], %[res], #1\n"                                             \
+        : [res] "+r" (result)                                                  \
+        : : "x0"                                                               \
+    )
+#endif
+
+#ifndef IS_SYSREG_BIT_DISABLED
+#define IS_SYSREG_BIT_DISABLED(encoding, result, lsb)                          \
+    __asm__ __volatile__(                                                      \
+        ".word "#encoding"\n"                                                  \
+        "mov %[res], x0\n"                                                     \
+        "lsr %[res], %[res], #"#lsb"\n"                                        \
+        "mvn %[res], %[res]\n"                                                 \
+        "and %[res], %[res], #1\n"                                             \
+        : [res] "+r" (result)                                                  \
+        : : "x0"                                                               \
+    )
+#endif
+
+#ifndef SET_SYSREG_BITS_BY_MASK
+#define SET_SYSREG_BITS_BY_MASK(get_encoding, set_encoding, val, mask)         \
+    __asm__ __volatile__(                                                      \
+        ".word "#get_encoding"\n"                                              \
+        "mov %[v], x0\n"                                                       \
+        "orr %[v], %[v], %[m]\n"                                               \
+        "mov x0, %[v]\n"                                                       \
+        ".word "#set_encoding"\n"                                              \
+        : [v] "+r" (val)                                                       \
+        : [m] "r" (mask)                                                       \
+        : "x0"                                                                 \
+    )
+#endif
+
+#ifndef SET_SYSREG_BITS_BY_MASK_FUNC
+#define SET_SYSREG_BITS_BY_MASK_FUNC(get_encoding, set_encoding, bitmask)      \
+    uint64_t val;                                                              \
+    uint64_t mask = bitmask;                                                   \
+    SET_SYSREG_BITS_BY_MASK(get_encoding, set_encoding, val, mask);
+#endif
+
+#ifndef CLEAR_SYSREG_BITS_BY_MASK
+#define CLEAR_SYSREG_BITS_BY_MASK(get_encoding, set_encoding, val, mask)       \
+    __asm__ __volatile__(                                                      \
+        ".word "#get_encoding"\n"                                              \
+        "mov %[v], x0\n"                                                       \
+        "mvn %[m], %[m]\n"                                                     \
+        "and %[v], %[v], %[m]\n"                                               \
+        "mov x0, %[v]\n"                                                       \
+        ".word "#set_encoding"\n"                                              \
+        : [v] "+r" (val), [m] "+r" (mask)                                      \
+        : : "x0"                                                               \
+    )
+#endif
+
+#ifndef CLEAR_SYSREG_BITS_BY_MASK_FUNC
+#define CLEAR_SYSREG_BITS_BY_MASK_FUNC(get_encoding, set_encoding, bitmask)    \
+    uint64_t val;                                                              \
+    uint64_t mask = bitmask;                                                   \
+    CLEAR_SYSREG_BITS_BY_MASK(get_encoding, set_encoding, val, mask);
+#endif
+
+#endif

--- a/shoulder/__main__.py
+++ b/shoulder/__main__.py
@@ -27,11 +27,13 @@ from shoulder.logger import logger
 from shoulder.parser import *
 from shoulder.generator import *
 from shoulder.filter import filter_all
-from shoulder.transform import transform_all
+from shoulder.transform import *
 
 regs = parse_registers(config.xml_register_dir)
 logger.debug("Registers parsed: " + str(len(regs)))
 
+regs = transforms["remove_reserved_0"].transform(regs)
+regs = transforms["remove_reserved_1"].transform(regs)
 regs = filter_all(regs)
 regs = transform_all(regs)
 logger.debug("Registers remaining after filters: " + str(len(regs)))

--- a/shoulder/access_attributes.py
+++ b/shoulder/access_attributes.py
@@ -1,0 +1,90 @@
+#
+# Shoulder
+# Copyright (C) 2018 Assured Information Security, Inc.
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in all
+# copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+
+class AccessAttributes(object):
+    def __init__(self):
+        self.op0 = None
+        self.op1 = None
+        self.op2 = None
+        self.crn = None
+        self.crm = None
+        self.mnemonic = None
+
+    def __str__(self):
+        msg = "{mnemonic}\n"
+        msg += "op0: {op0}\n"
+        msg += "op1: {op1}\n"
+        msg += "op2: {op2}\n"
+        msg += "CRn: {crn}\n"
+        msg += "CRm: {crm}\n"
+        msg = msg.format(**self.__dict__)
+
+        msg += "Get Encoding:\n\t{bin_enc}\n\t{hex_enc}\n\t{dec_enc}\n"
+        msg = msg.format(
+            bin_enc = bin(self.sysreg_get_encoding()),
+            hex_enc = hex(self.sysreg_get_encoding()),
+            dec_enc = self.sysreg_get_encoding()
+        )
+
+        msg += "Set Encoding:\n\t{bin_enc}\n\t{hex_enc}\n\t{dec_enc}"
+        msg = msg.format(
+            bin_enc = bin(self.sysreg_set_encoding()),
+            hex_enc = hex(self.sysreg_set_encoding()),
+            dec_enc = self.sysreg_set_encoding()
+        )
+
+        return msg
+
+    def is_valid(self):
+        if self.op0 is None: return False
+        if self.op1 is None: return False
+        if self.op2 is None: return False
+        if self.crn is None: return False
+        if self.crm is None: return False
+        if self.mnemonic is None: return False
+        return True
+
+    def sysreg_get_encoding(self):
+        encoding = 0
+
+        header = 0b1101010100
+        l = 0b1
+        return_reg = 0b00000
+
+        encoding = encoding | (header << 22) | (l << 21) | (self.op0 << 19) |  \
+                   (self.op1 << 16) | (self.crn << 12) | (self.crm << 8) |     \
+                   (self.op2 << 5) | return_reg
+
+        return encoding
+
+    def sysreg_set_encoding(self):
+        encoding = 0
+
+        header = 0b1101010100
+        l = 0b0
+        value_reg = 0b00000
+
+        encoding = encoding | (header << 22) | (l << 21) | (self.op0 << 19) |  \
+                   (self.op1 << 16) | (self.crn << 12) | (self.crm << 8) |     \
+                   (self.op2 << 5) | value_reg
+
+        return encoding

--- a/shoulder/config.py
+++ b/shoulder/config.py
@@ -134,6 +134,10 @@ config.add_configuration(c)
 # Function generation options
 # -----------------------------------------------------------------------------
 
+c = Configuration("encoded_functions", False)
+c.description = "Use 32bit encoded instruction values instead of traditional mnemonic accesses"
+config.add_configuration(c)
+
 c = Configuration("register_read_function", "get")
 c.description = "Name of generated functions for reading registers"
 config.add_configuration(c)
@@ -227,4 +231,8 @@ config.add_configuration(c)
 
 c = Configuration("accessor_macros_path", os.path.join(_include_dir, "aarch64_gcc_accessor_macros.h"))
 c.description = "Path to C/C++ register access macros"
+config.add_configuration(c)
+
+c = Configuration("encoded_macros_path", os.path.join(_include_dir, "encoded_accessor_macros.h"))
+c.description = "Path to C/C++ register encoded access macros"
 config.add_configuration(c)

--- a/shoulder/gadget/header_depends.py
+++ b/shoulder/gadget/header_depends.py
@@ -20,6 +20,8 @@
 # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 # SOFTWARE.
 
+from shoulder.config import config
+
 def header_depends(decorated):
     """
     A decorator gadget that generates dependency-includes for C/C++ header files
@@ -32,6 +34,8 @@ def header_depends(decorated):
 
     def header_depends_decorator(generator, outfile, *args, **kwargs):
         outfile.write("#include <stdint.h>\n")
+        if config.encoded_functions:
+            outfile.write("#include \"encoded_accessor_macros.h\"\n")
         outfile.write("#include \"aarch64_gcc_accessor_macros.h\"\n")
         outfile.write("\n")
         decorated(generator, outfile, *args, **kwargs)

--- a/shoulder/generator/__init__.py
+++ b/shoulder/generator/__init__.py
@@ -53,6 +53,9 @@ def generate_all(objects, outdir):
         if os.path.exists(config.accessor_macros_path):
             shutil.copy(config.accessor_macros_path, sub_outdir)
 
+        if os.path.exists(config.encoded_macros_path):
+            shutil.copy(config.encoded_macros_path, sub_outdir)
+
         g = generator_class()
         g.generate(objects, sub_outdir)
 

--- a/shoulder/register.py
+++ b/shoulder/register.py
@@ -27,7 +27,7 @@ class Register(object):
     def __init__(self):
         self.name = None
         self.long_name = None
-        self.access_mnemonic = None
+        self.access_attributes = None
         self.purpose = None
         self.size = None
         self.offset = None
@@ -58,8 +58,8 @@ class Register(object):
             logger.debug("Register " + str(self.name) + " has no long name")
             return False
 
-        if self.access_mnemonic is None:
-            logger.debug("Register " + str(self.name) + " has no access mnemonic")
+        if self.access_attributes is None:
+            logger.debug("Register " + str(self.name) + " has no access attributes")
             return False
 
         if self.size is None:

--- a/shoulder/transform/n_counter_to_zero.py
+++ b/shoulder/transform/n_counter_to_zero.py
@@ -50,13 +50,13 @@ class NCounterToZero(AbstractTransform):
                     ))
                     f.name = new_name
 
-        new_access_mnemonic = reg.access_mnemonic.replace("<n>", "0")
-        if new_access_mnemonic != reg.access_mnemonic:
+        new_access_mnemonic = reg.access_attributes.mnemonic.replace("<n>", "0")
+        if new_access_mnemonic != reg.access_attributes.mnemonic:
             logger.debug("Access mnemonic for {r}: {name} -> {new_name}".format(
                 r = reg.name,
-                name = reg.access_mnemonic,
+                name = reg.access_attributes.mnemonic,
                 new_name = new_access_mnemonic
             ))
-            reg.access_mnemonic = new_access_mnemonic
+            reg.access_attributes.mnemonic = new_access_mnemonic
 
         return reg


### PR DESCRIPTION
Adds the option to access system registers using their binary encoding as opposed to the mnemonic encoding previously used.

For example, to write to the SPSR_EL1 register using a mnemonic access, you would use the assembly instruction `msr spsr_el1, <value>`. This is interpreted as the 32bit binary instruction with the value `0xD5184000`. All system register reads and writes have a similar format:


![image](https://user-images.githubusercontent.com/11948858/55826747-e7787880-5ac5-11e9-8417-d151b093e8c9.png)
From ARM Architecture Reference Manual C5.1.2
- If reading a register (`mrs` access) --> L = 1
- If writing a register (`msr` access) --> L = 0
- `op0`, `op1`, `op2`, `CRn`, and `CRm` can all be parsed from the register XML file under the `./registers/register/access_mechanisms/access_mechanism/encoding/enc` nodes
- `Rt` is the "return" register. This is the register you want the value of the read to be stored in or the register that contains the value you want to write 
    - For now, we are always setting this to 0, so we will always use the x0 register for reads and writes

So to continue our example, from the SPSR_EL1 XML file, we can determine that:
- L = 0 since we are writing
- op0 = 0b11
- op1 = 0b000
- CRn = 0b0100
- CRm = 0b0000
- op2 = 0b000
- Rt = 0b00000 since we are using x0 to contain our write value

Therefore, our binary encoding is `1101010100 0 11 000 0100 0000 000 00000` which is equal to `0xD5184000`. Then, instead of writing `msr spsr_el1, <val>`, instead we can write:
```
mv x0, <val>
.word 0xD5184000
```

This is all included in this PR, so the only thing a user will have to do is set the config variable `config.encoded_functions = True` to enable the use of these encoded binary accesses. If False, it will use the mnemonic accesses we have been using previously. The default value is True.

