### PR TITLE
Access mechanisms rebased

### DIFF
--- a/shoulder/__main__.py
+++ b/shoulder/__main__.py
@@ -20,22 +20,10 @@
 # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 # SOFTWARE.
 
-import os
-
 from shoulder.config import config
 from shoulder.logger import logger
 from shoulder.parser import *
 from shoulder.generator import *
-from shoulder.filter import filter_all
-from shoulder.transform import *
 
 regs = parse_registers(config.xml_register_dir)
-logger.debug("Registers parsed: " + str(len(regs)))
-
-regs = transforms["remove_reserved_0"].transform(regs)
-regs = transforms["remove_reserved_1"].transform(regs)
-regs = filter_all(regs)
-regs = transform_all(regs)
-logger.debug("Registers remaining after filters: " + str(len(regs)))
-
 generate_all(regs, config.shoulder_output_dir)

--- a/shoulder/config.py
+++ b/shoulder/config.py
@@ -182,7 +182,7 @@ config.add_configuration(c)
 # C options
 # -----------------------------------------------------------------------------
 
-c = Configuration("c_prefix", "aarch")
+c = Configuration("c_prefix", "")
 c.description = "Prefix to place in front of generated C functions"
 config.add_configuration(c)
 

--- a/shoulder/filter/__init__.py
+++ b/shoulder/filter/__init__.py
@@ -46,6 +46,7 @@ filters["gic"] = gic.GICRegisterFilter()
 filters["loregion"] = loregion.LORegionRegisterFilter()
 filters["misc"] = misc.MiscelaneousRegisterFilter()
 filters["mpam"] = mpam.MPAMRegisterFilter()
+filters["no_access_mechanism"] = no_access_mechanism.NoAccessMechanismFilter()
 filters["scxtnum"] = scxtnum.SCXTNUMRegisterFilter()
 filters["statistical_profiling"] = \
     statistical_profiling.StatisticalProfilingRegisterFilter()

--- a/shoulder/filter/no_access_mechanism.py
+++ b/shoulder/filter/no_access_mechanism.py
@@ -20,26 +20,17 @@
 # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 # SOFTWARE.
 
-from shoulder.transform.abstract_transform import AbstractTransform
-from shoulder.logger import logger
+from shoulder.filter.abstract_filter import AbstractFilter
 
-class RemoveReserved1(AbstractTransform):
+
+class NoAccessMechanismFilter(AbstractFilter):
     @property
     def description(self):
-        d = "removing reserved 1 (RES1) fields"
-        return d
+        return "registers with no access mechanism"
 
-    def do_transform(self, reg):
-        for fs in reg.fieldsets:
-            fs_len = len(fs.fields)
-            fs.fields = [field for field in fs.fields if not "1" == field.name]
+    def do_filter(self, reg):
+        for key, am_list in reg.access_mechanisms.items():
+            if am_list:
+                return True
 
-            count = fs_len - len(fs.fields)
-            if count:
-                logger.debug("Removed {count} field{s} from {reg}".format(
-                    count = count,
-                    reg = reg.name,
-                    s = "" if count == 1 else "s"
-                ))
-
-        return reg
+        return False

--- a/shoulder/gadget/c/__init__.py
+++ b/shoulder/gadget/c/__init__.py
@@ -20,19 +20,5 @@
 # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 # SOFTWARE.
 
-from .gadget_properties import GadgetProperties
-from .header_depends import header_depends
-from .include_guard import include_guard
-from .license import license
-from .c import *
-from .cxx import *
-
-from typing import List
-
-def create_gadget_properties() -> List[GadgetProperties]:
-    properties_subclasses = [cls for cls in GadgetProperties.__subclasses__()]
-    properties = {}
-    for subclass in properties_subclasses:
-        p = subclass()
-        properties[p.gadget_name] = p
-    return properties
+from .function_definition import function_definition
+from .enum import enum

--- a/shoulder/gadget/c/enum.py
+++ b/shoulder/gadget/c/enum.py
@@ -1,0 +1,93 @@
+#
+# Shoulder
+# Copyright (C) 2018 Assured Information Security, Inc.
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in all
+# copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+
+import io
+
+from dataclasses import dataclass
+from shoulder.gadget.gadget_properties import GadgetProperties
+
+@dataclass
+class properties(GadgetProperties):
+    """ Properties of the enum gadget """
+
+    gadget_name: str = "shoulder.c.enum"
+    """ Name of the gadget these properties apply to """
+
+    name: str = ""
+    """ If not empty, used as a name (typedef) for the enum """
+
+    indent: int = 0
+    """ The indentation level to generate at """
+
+def enum(decorated):
+    """
+    A decorator gadget that generates a C enum declaration. The function
+    decorated by this gadget should generate the enum's contents.
+
+    Usage:
+        properties.name = "my_enum"
+
+        @enum
+        function(generator, outfile, ...):
+            outfile.write("contents,\ninside,\nthe,\nenum")
+
+    Generates:
+        typedef enum {
+            contents,
+            inside,
+            the,
+            enum
+        } my_enum;
+    """
+    def enum_decorator(generator, outfile, *args, **kwargs):
+        properties = generator.gadgets["shoulder.c.enum"]
+
+        indent_str = ""
+        for level in range(0, properties.indent):
+            indent_str += "\t"
+        outfile.write(indent_str)
+
+        if properties.name:
+            outfile.write("typedef ")
+
+        outfile.write("enum {")
+
+        contents = io.StringIO()
+        decorated(generator, contents, *args, **kwargs)
+
+        lines = contents.getvalue().splitlines()
+        if len(lines) == 1:
+            outfile.write(" ")
+            outfile.write(lines[0])
+            outfile.write(" ")
+        elif len(lines) > 1:
+            outfile.write("\n")
+            for line in lines:
+                outfile.write(indent_str + "\t" + line + "\n")
+            outfile.write(indent_str)
+
+        outfile.write("}")
+        if properties.name:
+            outfile.write(str(properties.name))
+        outfile.write(";\n\n")
+
+    return enum_decorator

--- a/shoulder/gadget/c/function_definition.py
+++ b/shoulder/gadget/c/function_definition.py
@@ -1,0 +1,113 @@
+#
+# Shoulder
+# Copyright (C) 2018 Assured Information Security, Inc.
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in all
+# copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+
+import io
+import typing
+
+from dataclasses import dataclass, field
+from shoulder.gadget.gadget_properties import GadgetProperties
+
+@dataclass
+class properties(GadgetProperties):
+    """ Properties of the C function_definition gadget """
+
+    gadget_name: str = "shoulder.c.function_definition"
+    """ The name of the C function to generate """
+
+    name: str = "function_definition"
+    """ The name of the C function to generate """
+
+    args: typing.List[typing.Tuple[str, str]] = \
+        field(default_factory= lambda: [])
+    """ List of argmuent type/name tuples for the generated function """
+
+    return_type: str = "uint64_t"
+    """ Return type for the generated function """
+
+    inline: bool = True
+    """ Set True to declare function as inline """
+
+    indent: int = 0
+    """ The indentation level to generate at """
+
+def function_definition(decorated):
+    """
+    A decorator gadget that generates a C function declaration. The function
+    decorated by this gadget should generate the function's body.
+
+    Usage:
+        properties.name = "my_function"
+        properties.return_type = "uint64_t"
+        properties.args = [("uint64_t", "arg1")]
+
+        @function_definition
+        function(generator, outfile, ...):
+            outfile.write("contents inside function body")
+
+    Generates:
+        inline uint64_t my_function(uint64_t arg1)
+        { contents inside function body }
+    """
+    def function_definition_decorator(generator, outfile, *args, **kwargs):
+        properties = generator.gadgets["shoulder.c.function_definition"]
+
+        indent_str = ""
+        for level in range(0, properties.indent):
+            indent_str += "\t"
+        outfile.write(indent_str)
+
+        if properties.inline == True:
+            outfile.write("inline ")
+
+        outfile.write(str(properties.return_type) + " ")
+        outfile.write(str(properties.name))
+
+
+        if len(properties.args) == 0:
+            outfile.write("(void)\n")
+        else:
+            outfile.write("(")
+            for idx, arg_pair in enumerate(properties.args):
+                if idx > 0:
+                    outfile.write(", ")
+                outfile.write(str(arg_pair[0]) + " ")
+                outfile.write(str(arg_pair[1]))
+            outfile.write(")\n")
+
+        outfile.write(indent_str + "{")
+        contents = io.StringIO()
+        decorated(generator, contents, *args, **kwargs)
+
+        lines = contents.getvalue().splitlines()
+        if len(lines) == 1:
+            outfile.write(" ")
+            outfile.write(lines[0])
+            outfile.write(" ")
+        elif len(lines) > 1:
+            outfile.write("\n")
+            for line in lines:
+                outfile.write(indent_str + "\t" + line + "\n")
+            outfile.write(indent_str)
+
+        outfile.write("}\n\n")
+
+    return function_definition_decorator

--- a/shoulder/generator/c_header_generator.py
+++ b/shoulder/generator/c_header_generator.py
@@ -21,463 +21,767 @@
 # SOFTWARE.
 
 import os
+import textwrap
 
 from shoulder.generator.abstract_generator import AbstractGenerator
-from shoulder.model.register import Register
 from shoulder.logger import logger
 from shoulder.config import config
-from shoulder.exception import *
-from shoulder.gadget import *
+from shoulder.exception import ShoulderGeneratorException
+from shoulder.filter import filters
+from shoulder.transform import transforms
+import shoulder.gadget
+
 
 class CHeaderGenerator(AbstractGenerator):
     def generate(self, objects, outpath):
         try:
+            regs = objects
+
+            regs = transforms["remove_reserved_0"].transform(regs)
+            regs = transforms["remove_reserved_1"].transform(regs)
+            regs = transforms["remove_reserved_sign_extended"].transform(regs)
+            regs = transforms["remove_implementation_defined"].transform(regs)
+            regs = transforms["special_to_underscore"].transform(regs)
+            regs = transforms["remove_coprocessor_am"].transform(regs)
+            regs = transforms["remove_memory_mapped_am"].transform(regs)
+            regs = transforms["remove_system_vector_am"].transform(regs)
+            regs = transforms["remove_system_banked_am"].transform(regs)
+            regs = transforms["remove_system_immediate_am"].transform(regs)
+            regs = transforms["remove_redundant_fields"].transform(regs)
+            regs = transforms["unique_fieldset_names"].transform(regs)
+
+            regs = filters["no_access_mechanism"].filter_exclusive(regs)
+
             outfile_path = os.path.abspath(os.path.join(outpath, "shoulder.h"))
             logger.info("Generating C Header: " + str(outfile_path))
             with open(outfile_path, "w") as outfile:
-                self._generate(outfile, objects)
+                self._generate(outfile, regs)
 
         except Exception as e:
             msg = "{g} failed to generate output {out}: {exception}".format(
-                g = str(type(self).__name__),
-                out = outpath,
-                exception = e
-            )
+                g=str(type(self).__name__),
+                out=outpath,
+                exception=e)
             raise ShoulderGeneratorException(msg)
 
-    @license
-    @include_guard
-    @header_depends
-    def _generate(self, outfile, objects):
-        for obj in objects:
-            if(isinstance(obj, Register)):
-                if not obj.is_sysreg: return
+    @shoulder.gadget.license
+    @shoulder.gadget.include_guard
+    @shoulder.gadget.header_depends
+    def _generate(self, outfile, regs):
 
-                logger.debug("Writing register: " + str(obj.name))
-                self._generate_register(outfile, obj)
-            else:
-                msg = "Cannot generate object of unsupported {t} type".format(
-                    t = type(obj)
-                )
-                raise ShoulderGeneratorException(msg)
+        for reg in regs:
+            self.gadgets["shoulder.c.enum"].indent = 0
+            self.gadgets["shoulder.c.function_definition"].indent = 0
 
-    def _generate_register(self, outfile, reg):
-        self._generate_register_comment(outfile, reg)
-        self._generate_sysreg_get(outfile, reg)
-        if reg.is_writable:
-            self._generate_sysreg_set(outfile, reg)
+            self._generate_register_comment(outfile, reg)
+            self._generate_register_get(outfile, reg)
+            self._generate_register_set(outfile, reg)
 
-        outfile.write("\n")
-        self._generate_register_fieldsets(outfile, reg)
+            self.gadgets["shoulder.c.enum"].indent = 1
+            self.gadgets["shoulder.c.function_definition"].indent = 1
 
-    def _generate_register_fieldsets(self, outfile, reg):
-        if not reg.is_sysreg: return
-
-        fieldsets = reg.fieldsets
-        if len(fieldsets) == 1:
-            self._generate_fieldset(outfile, reg, fieldsets[0])
-        elif len(fieldsets) > 1:
-            for idx, fieldset in enumerate(fieldsets):
+            for fieldset in reg.fieldsets:
                 self._generate_fieldset_comment(outfile, fieldset)
-                temp = reg.name
-                reg.name = reg.name + "_fieldset_" + str(idx + 1)
-                self._generate_fieldset(outfile, reg, fieldset)
-                reg.name = temp
-        else:
-            logger.debug("No fieldsets generated for system register " + str(reg.name))
 
-    def _generate_fieldset(self, outfile, reg, fieldset):
-        for field in fieldset.fields:
-            if(field.msb == field.lsb):
-                self._generate_bitfield_accessors(outfile, reg, field)
-            else:
-                self._generate_field_accessors(outfile, reg, field)
-            outfile.write("\n")
-
-    def _generate_field_accessors(self, outfile, reg, field):
-        self._generate_sysreg_register_field_read(outfile, reg, field)
-        self._generate_value_register_field_read(outfile, reg, field)
-        if reg.is_writable:
-            self._generate_sysreg_register_field_write(outfile, reg, field)
-            self._generate_value_register_field_write(outfile, reg, field)
-
-    def _generate_bitfield_accessors(self, outfile, reg, field):
-        self._generate_sysreg_is_bit_set(outfile, reg, field)
-        self._generate_value_is_bit_set(outfile, reg, field)
-        self._generate_sysreg_is_bit_cleared(outfile, reg, field)
-        self._generate_value_is_bit_cleared(outfile, reg, field)
-        if reg.is_writable:
-            self._generate_sysreg_bit_set(outfile, reg, field)
-            self._generate_value_bit_set(outfile, reg, field)
-            self._generate_sysreg_bit_clear(outfile, reg, field)
-            self._generate_value_bit_clear(outfile, reg, field)
+                for field in fieldset.fields:
+                    self._generate_field_constants(outfile, reg, field)
+                    if field.msb == field.lsb:
+                        self._generate_bitfield_set(outfile, reg, field)
+                        self._generate_bitfield_set_val(outfile, reg, field)
+                        self._generate_bitfield_is_set(outfile, reg, field)
+                        self._generate_bitfield_is_set_val(outfile, reg, field)
+                        self._generate_bitfield_clear(outfile, reg, field)
+                        self._generate_bitfield_clear_val(outfile, reg, field)
+                        self._generate_bitfield_is_clear(outfile, reg, field)
+                        self._generate_bitfield_is_clear_val(outfile, reg, field)
+                    else:
+                        self._generate_field_get(outfile, reg, field)
+                        self._generate_field_get_val(outfile, reg, field)
+                        self._generate_field_set(outfile, reg, field)
+                        self._generate_field_set_val(outfile, reg, field)
 
     def _generate_register_comment(self, outfile, reg):
-        reg_comment = "// {name} ({long_name})\n// {purpose}\n".format(
-            name = str(reg.name),
-            long_name = str(reg.long_name),
-            purpose = str(reg.purpose)
+        comment = "// {name} ({long_name})\n".format(
+            name=str(reg.name),
+            long_name=str(reg.long_name)
         )
-        outfile.write(reg_comment)
+        outfile.write(comment)
+
+        comment = str(reg.purpose)
+        wrapped = textwrap.wrap(comment, width=75)
+        for line in wrapped:
+            line = "// " + str(line) + "\n"
+            outfile.write(line)
 
     def _generate_fieldset_comment(self, outfile, fieldset):
-        if(fieldset.condition is not None):
-            fieldset_comment = "\t// Fieldset valid when: {comment}\n".format(
-                    comment = str(fieldset.condition)
-                )
-            outfile.write(fieldset_comment)
+        if fieldset.condition is not None:
+            fieldset_comment = "Fieldset valid when: {comment}\n".format(
+                comment=str(fieldset.condition))
+            wrapped = textwrap.wrap(fieldset_comment, width=71)
+            for line in wrapped:
+                line = "\t// " + str(line) + "\n"
+                outfile.write(line)
 
-    def _generate_sysreg_get(self, outfile, reg):
-        access_name = str(reg.access_attributes.mnemonic).lower()
+# ----------------------------------------------------------------------------
+# register_get
+# ----------------------------------------------------------------------------
+
+    def _generate_register_get(self, outfile, reg):
+        """
+        Generate a C function that reads the given register
+        """
+
+        rname = reg.name.lower()
+        prefix = self._register_function_prefix(reg)
+        suffix = config.register_read_function
+        if reg.size == 32:
+            size_type = "uint32_t"
+        else:
+            size_type = "uint64_t"
+
+        gadget = self.gadgets["shoulder.c.function_definition"]
+        gadget.name = prefix + "_" + rname + "_" + suffix
+        gadget.return_type = size_type
+        gadget.args = []
+
+        if reg.access_mechanisms["mrs_register"]:
+            am = reg.access_mechanisms["mrs_register"][0]
+            self._generate_mrs_register_get(outfile, reg, am)
+
+        elif reg.access_mechanisms["mrs_banked"]:
+            am = reg.access_mechanisms["mrs_banked"][0]
+            self._generate_mrs_banked_get(outfile, reg, am)
+
+        elif reg.access_mechanisms["mrc"]:
+            am = reg.access_mechanisms["mrc"][0]
+            self._generate_mrc_get(outfile, reg, am)
+
+        elif reg.access_mechanisms["mrrc"]:
+            am = reg.access_mechanisms["mrrc"][0]
+            self._generate_mrrc_get(outfile, reg, am)
+
+        elif reg.access_mechanisms["vmrs"]:
+            am = reg.access_mechanisms["vmrs"][0]
+            self._generate_vmrs_get(outfile, reg, am)
+
+        elif reg.access_mechanisms["ldr"]:
+            am = reg.access_mechanisms["ldr"][0]
+            self._generate_ldr_get(outfile, reg, am)
+
+    @shoulder.gadget.c.function_definition
+    def _generate_mrs_register_get(self, outfile, reg, am):
         if config.encoded_functions:
-            access_name = hex(reg.access_attributes.sysreg_get_encoding())
+            key = hex(am.binary_encoded())
+        else:
+            key = am.operand_mnemonic.lower()
 
-        reg_getter = "inline {size_t} {c_prefix}{c_suffix}_{regname}_{funcname}(void) "
-        reg_getter += "{{ GET_SYSREG_FUNC({accessname}) }}\n"
-        reg_getter = reg_getter.format(
-            size_t = "uint" + str(reg.size) + "_t",
-            c_prefix = config.c_prefix,
-            c_suffix = str(reg.size),
-            regname = str(reg.name).lower(),
-            funcname = config.register_read_function,
-            accessname = access_name
-        )
+        reg_getter = "GET_SYSREG_FUNC({key})".format(key=key)
         outfile.write(reg_getter)
 
-    def _generate_sysreg_set(self, outfile, reg):
-        access_name = str(reg.access_attributes.mnemonic).lower()
-        if config.encoded_functions:
-            access_name = hex(reg.access_attributes.sysreg_set_encoding())
+    @shoulder.gadget.c.function_definition
+    def _generate_mrs_banked_get(self, outfile, reg, am):
+        outfile.write("TODO: get register using mrs_banked")
 
-        reg_setter = "inline void {c_prefix}{c_suffix}_{regname}_{funcname}({size_t} val) "
-        reg_setter += "{{ SET_SYSREG_BY_VALUE_FUNC({accessname}, val) }}\n"
-        reg_setter = reg_setter.format(
-            c_prefix = config.c_prefix,
-            c_suffix = str(reg.size),
-            regname = str(reg.name).lower(),
-            funcname = config.register_write_function,
-            size_t = "uint" + str(reg.size) + "_t",
-            accessname = access_name
-        )
+    @shoulder.gadget.c.function_definition
+    def _generate_mrc_get(self, outfile, reg, am):
+        outfile.write("TODO: get register using mrc")
+
+    @shoulder.gadget.c.function_definition
+    def _generate_mrrc_get(self, outfile, reg, am):
+        outfile.write("TODO: get register using mrrc")
+
+    @shoulder.gadget.c.function_definition
+    def _generate_vmrs_get(self, outfile, reg, am):
+        outfile.write("TODO: get register using vmrs")
+
+    @shoulder.gadget.c.function_definition
+    def _generate_ldr_get(self, outfile, reg, am):
+        outfile.write("TODO: get register using ldr")
+
+# ----------------------------------------------------------------------------
+# register_set
+# ----------------------------------------------------------------------------
+
+    def _generate_register_set(self, outfile, reg):
+        """
+        Generate a C function that writes the given register
+        """
+
+        rname = reg.name.lower()
+        prefix = self._register_function_prefix(reg)
+
+        suffix = config.register_write_function
+        if reg.size == 32:
+            size_type = "uint32_t"
+        else:
+            size_type = "uint64_t"
+
+        gadget = self.gadgets["shoulder.c.function_definition"]
+        gadget.name = prefix + "_" + rname + "_" + suffix
+        gadget.return_type = size_type
+        gadget.args = [(size_type, "val")]
+
+        if reg.access_mechanisms["msr_register"]:
+            am = reg.access_mechanisms["msr_register"][0]
+            self._generate_msr_register_set(outfile, reg, am)
+
+        elif reg.access_mechanisms["mcr"]:
+            am = reg.access_mechanisms["mcr"][0]
+            self._generate_mcr_set(outfile, reg, am)
+
+        elif reg.access_mechanisms["mcrr"]:
+            am = reg.access_mechanisms["mcrr"][0]
+            self._generate_mcrr_set(outfile, reg, am)
+
+        elif reg.access_mechanisms["msr_banked"]:
+            am = reg.access_mechanisms["msr_banked"][0]
+            self._generate_msr_banked_set(outfile, reg, am)
+
+        elif reg.access_mechanisms["msr_immediate"]:
+            am = reg.access_mechanisms["msr_immediate"][0]
+            self._generate_msr_immediate_set(outfile, reg, am)
+
+        elif reg.access_mechanisms["vmsr"]:
+            am = reg.access_mechanisms["vmsr"][0]
+            self._generate_vmsr_set(outfile, reg, am)
+
+        elif reg.access_mechanisms["str"]:
+            am = reg.access_mechanisms["str"][0]
+            self._generate_str_set(outfile, reg, am)
+
+    @shoulder.gadget.c.function_definition
+    def _generate_msr_register_set(self, outfile, reg, am):
+        if config.encoded_functions:
+            key = hex(am.binary_encoded())
+        else:
+            key = am.operand_mnemonic.lower()
+
+        reg_setter = "SET_SYSREG_BY_VALUE_FUNC({key}, val)".format(key=key)
         outfile.write(reg_setter)
 
-    def _generate_sysreg_is_bit_set(self, outfile, reg, field):
-        access_name = str(reg.access_attributes.mnemonic).lower()
-        if config.encoded_functions:
-            access_name = hex(reg.access_attributes.sysreg_get_encoding())
+    @shoulder.gadget.c.function_definition
+    def _generate_mcr_set(self, outfile, reg, am):
+        outfile.write("TODO: set register using mcr")
 
-        accessor = "\tinline {size_t} {c_prefix}{c_suffix}_{regname}_{fieldname}_{func}() "
-        accessor += "{{ IS_SYSREG_BIT_ENABLED_FUNC({accessname}, {msb}) }}\n"
-        accessor = accessor.format(
-            size_t = "uint" + str(reg.size) + "_t",
-            c_prefix = config.c_prefix,
-            c_suffix = str(reg.size),
-            regname = str(reg.name).lower(),
-            fieldname = str(field.name).lower(),
-            func = config.is_bit_set_function,
-            accessname = access_name,
-            msb = field.msb
-        )
-        outfile.write(accessor)
+    @shoulder.gadget.c.function_definition
+    def _generate_mcrr_set(self, outfile, reg, am):
+        outfile.write("TODO: set register using mcrr")
 
-    def _generate_value_is_bit_set(self, outfile, reg, field):
-        accessor = "\tinline {size_t} {c_prefix}{c_suffix}_{regname}_{fieldname}_{func}_val({size_t} {arg}) "
-        accessor += "{{ IS_BIT_ENABLED_FUNC({arg}, {msb}) }}\n"
-        accessor = accessor.format(
-            size_t = "uint" + str(reg.size) + "_t",
-            c_prefix = config.c_prefix,
-            c_suffix = str(reg.size),
-            regname = str(reg.name).lower(),
-            fieldname = str(field.name).lower(),
-            func = config.is_bit_set_function,
-            arg = str(reg.access_attributes.mnemonic).lower() + "_val",
-            msb = field.msb
-        )
-        outfile.write(accessor)
+    @shoulder.gadget.c.function_definition
+    def _generate_msr_banked_set(self, outfile, reg, am):
+        outfile.write("TODO: set register using msr_banked")
 
-    def _generate_sysreg_is_bit_cleared(self, outfile, reg, field):
-        access_name = str(reg.access_attributes.mnemonic).lower()
-        if config.encoded_functions:
-            access_name = hex(reg.access_attributes.sysreg_get_encoding())
+    @shoulder.gadget.c.function_definition
+    def _generate_msr_immediate_set(self, outfile, reg, am):
+        outfile.write("TODO: set register using msr_immediate")
 
-        accessor = "\tinline {size_t} {c_prefix}{c_suffix}_{regname}_{fieldname}_{func}() "
-        accessor += "{{ IS_SYSREG_BIT_DISABLED_FUNC({accessname}, {msb}) }}\n"
-        accessor = accessor.format(
-            size_t = "uint" + str(reg.size) + "_t",
-            c_prefix = config.c_prefix,
-            c_suffix = str(reg.size),
-            regname = str(reg.name).lower(),
-            fieldname = str(field.name).lower(),
-            func = config.is_bit_cleared_function,
-            accessname = access_name,
-            msb = field.msb
-        )
-        outfile.write(accessor)
+    @shoulder.gadget.c.function_definition
+    def _generate_vmsr_set(self, outfile, reg, am):
+        outfile.write("TODO: set register using vmsr")
 
-    def _generate_value_is_bit_cleared(self, outfile, reg, field):
-        accessor = "\tinline {size_t} {c_prefix}{c_suffix}_{regname}_{fieldname}_{func}_val({size_t} {arg}) "
-        accessor += "{{ IS_BIT_DISABLED_FUNC({arg}, {msb}) }}\n"
-        accessor = accessor.format(
-            size_t = "uint" + str(reg.size) + "_t",
-            c_prefix = config.c_prefix,
-            c_suffix = str(reg.size),
-            regname = str(reg.name).lower(),
-            fieldname = str(field.name).lower(),
-            func = config.is_bit_cleared_function,
-            arg = str(reg.access_attributes.mnemonic).lower() + "_val",
-            msb = field.msb
-        )
-        outfile.write(accessor)
+    @shoulder.gadget.c.function_definition
+    def _generate_str_set(self, outfile, reg, am):
+        outfile.write("TODO: set register using str")
 
-    def _generate_sysreg_bit_set(self, outfile, reg, field):
-        mask_val = 0
-        mask = ""
+# ----------------------------------------------------------------------------
+# constants
+# ----------------------------------------------------------------------------
 
-        for i in range(field.lsb, field.msb + 1):
-            mask_val |= 1 << i
+    @shoulder.gadget.c.enum
+    def _generate_field_constants(self, outfile, reg, field):
+        """
+        Generate constants that describe a the given field in the given register
+        """
 
-        if reg.size == 32:
-            mask = "{0:#0{1}x}".format(mask_val, 10)
-        else:
-            mask = "{0:#0{1}x}".format(mask_val, 18)
-
-        accessor = "\tinline void {c_prefix}{c_suffix}_{regname}_{fieldname}_{func}() "
-        accessor = accessor.format(
-            c_prefix = config.c_prefix,
-            c_suffix = str(reg.size),
-            regname = str(reg.name).lower(),
-            fieldname = str(field.name).lower(),
-            func = config.bit_set_function,
+        constants = "{reg}_{field}_lsb = {lsb},\n"
+        constants += "{reg}_{field}_msb = {msb},\n"
+        constants += "{reg}_{field}_mask = {mask}"
+        constants = constants.format(
+            reg=reg.name.lower(),
+            field=field.name.lower(),
+            lsb=str(field.lsb),
+            msb=str(field.msb),
+            mask=self._field_mask_hex_string(reg, field)
         )
 
-        if config.encoded_functions:
-            accessor += "{{ SET_SYSREG_BITS_BY_MASK_FUNC({get_func}, {set_func}, {mask}) }}\n"
-            accessor = accessor.format(
-                get_func = hex(reg.access_attributes.sysreg_get_encoding()),
-                set_func = hex(reg.access_attributes.sysreg_set_encoding()),
-                mask = mask
-            )
-        else:
-            accessor += "{{ SET_SYSREG_BITS_BY_MASK_FUNC({accessname}, {mask}) }}\n"
-            accessor = accessor.format(
-                accessname = str(reg.access_attributes.mnemonic).lower(),
-                mask = mask
-            )
-        outfile.write(accessor)
+        outfile.write(constants)
 
-    def _generate_value_bit_set(self, outfile, reg, field):
-        mask_val = 0
-        mask = ""
+# ----------------------------------------------------------------------------
+# bitfield_set
+# ----------------------------------------------------------------------------
+    def _generate_bitfield_set(self, outfile, reg, field):
+        """
+        Generate a C function that sets/enables the given bitfield (to 1) in the
+        given register
+        """
 
-        for i in range(field.lsb, field.msb + 1):
-            mask_val |= 1 << i
-
-        if reg.size == 32:
-            mask = "{0:#0{1}x}".format(mask_val, 10)
-        else:
-            mask = "{0:#0{1}x}".format(mask_val, 18)
-
-        accessor = "\tinline {size_t} {c_prefix}{c_suffix}_{regname}_{fieldname}_{func}_val({size_t} {arg}) "
-        accessor += "{{ SET_BITS_BY_MASK_FUNC({arg}, {mask}) }}\n"
-        accessor = accessor.format(
-            size_t = "uint" + str(reg.size) + "_t",
-            c_prefix = config.c_prefix,
-            c_suffix = str(reg.size),
-            regname = str(reg.name).lower(),
-            fieldname = str(field.name).lower(),
-            func = config.bit_set_function,
-            arg = str(reg.access_attributes.mnemonic).lower() + "_val",
-            mask = mask
-        )
-        outfile.write(accessor)
-
-    def _generate_sysreg_bit_clear(self, outfile, reg, field):
-        mask_val = 0
-        mask = ""
-
-        for i in range(field.lsb, field.msb + 1):
-            mask_val |= 1 << i
-
-        if reg.size == 32:
-            mask = "{0:#0{1}x}".format(mask_val, 10)
-        else:
-            mask = "{0:#0{1}x}".format(mask_val, 18)
-
-        accessor = "\tinline void {c_prefix}{c_suffix}_{regname}_{fieldname}_{func}() "
-        accessor = accessor.format(
-            c_prefix = config.c_prefix,
-            c_suffix = str(reg.size),
-            regname = str(reg.name).lower(),
-            fieldname = str(field.name).lower(),
-            func = config.bit_clear_function,
-        )
-
-        if config.encoded_functions:
-            accessor += "{{ CLEAR_SYSREG_BITS_BY_MASK_FUNC({get_func}, {set_func}, {mask}) }}\n"
-            accessor = accessor.format(
-                get_func = hex(reg.access_attributes.sysreg_get_encoding()),
-                set_func = hex(reg.access_attributes.sysreg_set_encoding()),
-                mask = mask
-            )
-        else:
-            accessor += "{{ CLEAR_SYSREG_BITS_BY_MASK_FUNC({accessname}, {mask}) }}\n"
-            accessor = accessor.format(
-                accessname = str(reg.access_attributes.mnemonic).lower(),
-                mask = mask
-            )
-        outfile.write(accessor)
-
-    def _generate_value_bit_clear(self, outfile, reg, field):
-        mask_val = 0
-        mask = ""
-
-        for i in range(field.lsb, field.msb + 1):
-            mask_val |= 1 << i
-
-        if reg.size == 32:
-            mask = "{0:#0{1}x}".format(mask_val, 10)
-        else:
-            mask = "{0:#0{1}x}".format(mask_val, 18)
-
-        accessor = "\tinline {size_t} {c_prefix}{c_suffix}_{regname}_{fieldname}_{func}_val({size_t} {arg}) "
-        accessor += "{{ CLEAR_BITS_BY_MASK_FUNC({arg}, {mask}) }}\n"
-        accessor = accessor.format(
-            size_t = "uint" + str(reg.size) + "_t",
-            c_prefix = config.c_prefix,
-            c_suffix = str(reg.size),
-            regname = str(reg.name).lower(),
-            fieldname = str(field.name).lower(),
-            func = config.bit_clear_function,
-            arg = str(reg.access_attributes.mnemonic).lower() + "_val",
-            mask = mask
-        )
-        outfile.write(accessor)
-
-    def _generate_sysreg_register_field_read(self, outfile, reg, field):
-        mask_val = 0
-        mask = ""
-
-        for i in range(field.lsb, field.msb + 1):
-            mask_val |= 1 << i
-
-        if reg.size == 32:
-            mask = "{0:#0{1}x}".format(mask_val, 10)
-        else:
-            mask = "{0:#0{1}x}".format(mask_val, 18)
-
-        access_name = str(reg.access_attributes.mnemonic).lower()
-        if config.encoded_functions:
-            access_name = hex(reg.access_attributes.sysreg_get_encoding())
-
-        accessor = "\tinline {size_t} {c_prefix}{c_suffix}_{regname}_{fieldname}_{func}() "
-        accessor += "{{ GET_SYSREG_FIELD_FUNC({accessname}, {mask}, {lsb}) }}\n"
-        accessor = accessor.format(
-            size_t = "uint" + str(reg.size) + "_t",
-            c_prefix = config.c_prefix,
-            c_suffix = str(reg.size),
-            regname = str(reg.name).lower(),
-            fieldname = str(field.name).lower(),
-            func = config.register_field_read_function,
-            accessname = access_name,
-            mask = mask,
-            lsb = field.lsb
-        )
-        outfile.write(accessor)
-
-    def _generate_value_register_field_read(self, outfile, reg, field):
-        mask_val = 0
-        mask = ""
-
-        for i in range(field.lsb, field.msb + 1):
-            mask_val |= 1 << i
-
-        if reg.size == 32:
-            mask = "{0:#0{1}x}".format(mask_val, 10)
-        else:
-            mask = "{0:#0{1}x}".format(mask_val, 18)
-
-        accessor = "\tinline {size_t} {c_prefix}{c_suffix}_{regname}_{fieldname}_{func}_val({size_t} {arg}) "
-        accessor += "{{ GET_BITFIELD_FUNC({arg}, {mask}, {lsb}) }}\n"
-        accessor = accessor.format(
-            size_t = "uint" + str(reg.size) + "_t",
-            c_prefix = config.c_prefix,
-            c_suffix = str(reg.size),
-            regname = str(reg.name).lower(),
-            fieldname = str(field.name).lower(),
-            func = config.register_field_read_function,
-            arg = str(reg.access_attributes.mnemonic).lower() + "_val",
-            mask = mask,
-            lsb = field.lsb
-        )
-        outfile.write(accessor)
-
-    def _generate_sysreg_register_field_write(self, outfile, reg, field):
-        mask_val = 0
-        mask = ""
-
-        for i in range(field.lsb, field.msb + 1):
-            mask_val |= 1 << i
-
-        if reg.size == 32:
-            mask = "{0:#0{1}x}".format(mask_val, 10)
-        else:
-            mask = "{0:#0{1}x}".format(mask_val, 18)
-
-        accessor = "\tinline void {c_prefix}{c_suffix}_{regname}_{fieldname}_{func}({size_t} {arg}) "
-        accessor = accessor.format(
-            c_prefix = config.c_prefix,
-            c_suffix = str(reg.size),
-            regname = str(reg.name).lower(),
-            fieldname = str(field.name).lower(),
-            size_t = "uint" + str(reg.size) + "_t",
-            func = config.register_field_write_function,
-            arg = "value"
-        )
-
-        if config.encoded_functions:
-            accessor += "{{ SET_SYSREG_BITS_BY_VALUE_FUNC({get_func}, {set_func}, {arg}, {mask}, {lsb}) }}\n"
-            accessor = accessor.format(
-                get_func = hex(reg.access_attributes.sysreg_get_encoding()),
-                set_func = hex(reg.access_attributes.sysreg_set_encoding()),
-                arg = "value",
-                mask = mask,
-                lsb = field.lsb
-            )
-        else:
-            accessor += "{{ SET_SYSREG_BITS_BY_VALUE_FUNC({accessname}, {arg}, {mask}, {lsb}) }}\n"
-            accessor = accessor.format(
-                accessname = str(reg.access_attributes.mnemonic).lower(),
-                arg = "value",
-                mask = mask,
-                lsb = field.lsb
+        if reg.writeable():
+            gadget = self.gadgets["shoulder.c.function_definition"]
+            gadget.return_type = "void"
+            gadget.args = []
+            gadget.name = "{prefix}_{rname}_{fname}_{suffix}".format(
+                prefix=self._register_function_prefix(reg),
+                rname=reg.name.lower(),
+                fname=field.name.lower(),
+                suffix=config.bit_set_function
             )
 
-        outfile.write(accessor)
+            self._bitfield_set(outfile, reg, field)
 
-    def _generate_value_register_field_write(self, outfile, reg, field):
+    @shoulder.gadget.c.function_definition
+    def _bitfield_set(self, outfile, reg, field):
+        f_body = "{size} val = {reg_get}();\n"
+        f_body += "{reg_set}(val | {mask});"
+
+        f_body = f_body.format(
+            size=self._register_size_type(reg),
+            mask=self._field_mask_string(reg, field),
+            reg_get=self._register_read_function_name(reg),
+            reg_set=self._register_write_function_name(reg)
+        )
+
+        outfile.write(f_body)
+
+# ----------------------------------------------------------------------------
+# bitfield_set_val
+# ----------------------------------------------------------------------------
+    def _generate_bitfield_set_val(self, outfile, reg, field):
+        """
+        Generate a C function that sets the given bitfield (1) in an integer
+        value
+        """
+
+        if reg.writeable():
+            size_type = self._register_size_type(reg)
+
+            gadget = self.gadgets["shoulder.c.function_definition"]
+            gadget.return_type = size_type
+            gadget.args = [(size_type, "val")]
+            gadget.name = "{prefix}_{rname}_{fname}_{suffix}".format(
+                prefix=self._register_function_prefix(reg),
+                rname=reg.name.lower(),
+                fname=field.name.lower(),
+                suffix=config.bit_set_function + "_val"
+            )
+
+            self._bitfield_set_val(outfile, reg, field)
+
+    @shoulder.gadget.c.function_definition
+    def _bitfield_set_val(self, outfile, reg, field):
+        f_body = "return val | {mask};".format(
+            mask=self._field_mask_string(reg, field)
+        )
+        outfile.write(f_body)
+
+# ----------------------------------------------------------------------------
+# bitfield_is_set
+# ----------------------------------------------------------------------------
+
+    def _generate_bitfield_is_set(self, outfile, reg, field):
+        """
+        Generate a C function that checks if the given bitfield is set (1) in
+        the given register
+        """
+
+        if reg.readable():
+            size_type = self._register_size_type(reg)
+
+            gadget = self.gadgets["shoulder.c.function_definition"]
+            gadget.return_type = size_type
+            gadget.args = []
+            gadget.name = "{prefix}_{rname}_{fname}_{suffix}".format(
+                prefix=self._register_function_prefix(reg),
+                rname=reg.name.lower(),
+                fname=field.name.lower(),
+                suffix=config.is_bit_set_function
+            )
+
+            self._bitfield_is_set(outfile, reg, field)
+
+    @shoulder.gadget.c.function_definition
+    def _bitfield_is_set(self, outfile, reg, field):
+        f_body = "{size} val = {reg_get}();\n"
+        f_body += "return (val & {mask}) != 0;"
+
+        f_body = f_body.format(
+            size=self._register_size_type(reg),
+            mask=self._field_mask_string(reg, field),
+            reg_get=self._register_read_function_name(reg),
+        )
+
+        outfile.write(f_body)
+
+# ----------------------------------------------------------------------------
+# bitfield_is_set_val
+# ----------------------------------------------------------------------------
+    def _generate_bitfield_is_set_val(self, outfile, reg, field):
+        """
+        Generate a C function that checks if the given bitfield is set/enabled
+        (to 1) in an integer value
+        """
+
+        if reg.readable():
+            size_type = self._register_size_type(reg)
+
+            gadget = self.gadgets["shoulder.c.function_definition"]
+            gadget.return_type = size_type
+            gadget.args = [(size_type, "val")]
+            gadget.name = "{prefix}_{rname}_{fname}_{suffix}".format(
+                prefix=self._register_function_prefix(reg),
+                rname=reg.name.lower(),
+                fname=field.name.lower(),
+                suffix=config.is_bit_set_function + "_val"
+            )
+
+            self._bitfield_is_set_val(outfile, reg, field)
+
+    @shoulder.gadget.c.function_definition
+    def _bitfield_is_set_val(self, outfile, reg, field):
+        f_body = "return (val & {mask}) != 0;"
+
+        f_body = f_body.format(
+            mask=self._field_mask_string(reg, field)
+        )
+
+        outfile.write(f_body)
+
+# ----------------------------------------------------------------------------
+# bitfield_disable
+# ----------------------------------------------------------------------------
+    def _generate_bitfield_clear(self, outfile, reg, field):
+        """
+        Generate a C function that disables the given bitfield (to 1) in the
+        given register
+        """
+
+        if reg.writeable():
+            gadget = self.gadgets["shoulder.c.function_definition"]
+            gadget.return_type = "void"
+            gadget.args = []
+            gadget.name = "{prefix}_{rname}_{fname}_{suffix}".format(
+                prefix=self._register_function_prefix(reg),
+                rname=reg.name.lower(),
+                fname=field.name.lower(),
+                suffix=config.bit_clear_function
+            )
+
+            self._bitfield_clear(outfile, reg, field)
+
+    @shoulder.gadget.c.function_definition
+    def _bitfield_clear(self, outfile, reg, field):
+        f_body = "{size} val = {reg_get}();\n"
+        f_body += "{reg_set}(val & ~{mask});"
+
+        f_body = f_body.format(
+            size=self._register_size_type(reg),
+            mask=self._field_mask_string(reg, field),
+            reg_get=self._register_read_function_name(reg),
+            reg_set=self._register_write_function_name(reg)
+        )
+
+        outfile.write(f_body)
+
+# ----------------------------------------------------------------------------
+# bitfield_clear_val
+# ----------------------------------------------------------------------------
+    def _generate_bitfield_clear_val(self, outfile, reg, field):
+        """
+        Generate a C function that clears the given bitfield (1) in an integer
+        value
+        """
+
+        if reg.writeable():
+            size_type = self._register_size_type(reg)
+
+            gadget = self.gadgets["shoulder.c.function_definition"]
+            gadget.return_type = size_type
+            gadget.args = [(size_type, "val")]
+            gadget.name = "{prefix}_{rname}_{fname}_{suffix}".format(
+                prefix=self._register_function_prefix(reg),
+                rname=reg.name.lower(),
+                fname=field.name.lower(),
+                suffix=config.bit_clear_function + "_val"
+            )
+
+            self._bitfield_clear_val(outfile, reg, field)
+
+    @shoulder.gadget.c.function_definition
+    def _bitfield_clear_val(self, outfile, reg, field):
+        f_body = "return val & ~{mask};".format(
+            mask=self._field_mask_string(reg, field)
+        )
+        outfile.write(f_body)
+
+# ----------------------------------------------------------------------------
+# bitfield_is_disabled
+# ----------------------------------------------------------------------------
+    def _generate_bitfield_is_clear(self, outfile, reg, field):
+        """
+        Generate a C function that checks if the given bitfield is disabled (0)
+        in the given register
+        """
+
+        if reg.readable():
+            size_type = self._register_size_type(reg)
+
+            gadget = self.gadgets["shoulder.c.function_definition"]
+            gadget.return_type = size_type
+            gadget.args = []
+            gadget.name = "{prefix}_{rname}_{fname}_{suffix}".format(
+                prefix=self._register_function_prefix(reg),
+                rname=reg.name.lower(),
+                fname=field.name.lower(),
+                suffix=config.is_bit_cleared_function
+            )
+
+            self._bitfield_is_clear(outfile, reg, field)
+
+    @shoulder.gadget.c.function_definition
+    def _bitfield_is_clear(self, outfile, reg, field):
+        f_body = "{size} val = {reg_get}();\n"
+        f_body += "return (val & {mask}) == 0;"
+
+        f_body = f_body.format(
+            size=self._register_size_type(reg),
+            mask=self._field_mask_string(reg, field),
+            reg_get=self._register_read_function_name(reg),
+        )
+
+        outfile.write(f_body)
+
+# ----------------------------------------------------------------------------
+# bitfield_is_disabled_val
+# ----------------------------------------------------------------------------
+    def _generate_bitfield_is_clear_val(self, outfile, reg, field):
+        """
+        Generate a C function that checks if the given bitfield is cleared (0)
+        in an integer value
+        """
+
+        if reg.readable():
+            size_type = self._register_size_type(reg)
+
+            gadget = self.gadgets["shoulder.c.function_definition"]
+            gadget.return_type = size_type
+            gadget.args = [(size_type, "val")]
+            gadget.name = "{prefix}_{rname}_{fname}_{suffix}".format(
+                prefix=self._register_function_prefix(reg),
+                rname=reg.name.lower(),
+                fname=field.name.lower(),
+                suffix=config.is_bit_cleared_function + "_val"
+            )
+
+            self._bitfield_is_clear_val(outfile, reg, field)
+
+    @shoulder.gadget.c.function_definition
+    def _bitfield_is_clear_val(self, outfile, reg, field):
+        f_body = "return (val & {mask}) == 0;"
+
+        f_body = f_body.format(
+            size=self._register_size_type(reg),
+            mask=self._field_mask_string(reg, field),
+            reg_get=self._register_read_function_name(reg),
+        )
+
+        outfile.write(f_body)
+
+# ----------------------------------------------------------------------------
+# field_get
+# ----------------------------------------------------------------------------
+    def _generate_field_get(self, outfile, reg, field):
+        """
+        Generate a C function that reads the given field from the given register
+        """
+
+        if reg.readable():
+            size_type = self._register_size_type(reg)
+
+            gadget = self.gadgets["shoulder.c.function_definition"]
+            gadget.return_type = size_type
+            gadget.args = []
+            gadget.name = "{prefix}_{rname}_{fname}_{suffix}".format(
+                prefix=self._register_function_prefix(reg),
+                rname=reg.name.lower(),
+                fname=field.name.lower(),
+                suffix=config.register_field_read_function
+            )
+
+            self._field_get(outfile, reg, field)
+
+    @shoulder.gadget.c.function_definition
+    def _field_get(self, outfile, reg, field):
+        f_body = "{size} val = {reg_get}();\n"
+        f_body += "return (val & {mask}) >> {lsb};"
+
+        f_body = f_body.format(
+            size=self._register_size_type(reg),
+            mask=self._field_mask_string(reg, field),
+            lsb=self._field_lsb_string(reg, field),
+            reg_get=self._register_read_function_name(reg)
+        )
+
+        outfile.write(f_body)
+
+# ----------------------------------------------------------------------------
+# field_get_val
+# ----------------------------------------------------------------------------
+    def _generate_field_get_val(self, outfile, reg, field):
+        """
+        Generate a C function that reads the given field from an integer value
+        """
+
+        if reg.readable():
+            size_type = self._register_size_type(reg)
+
+            gadget = self.gadgets["shoulder.c.function_definition"]
+            gadget.return_type = size_type
+            gadget.args = [(size_type, "val")]
+            gadget.name = "{prefix}_{rname}_{fname}_{suffix}".format(
+                prefix=self._register_function_prefix(reg),
+                rname=reg.name.lower(),
+                fname=field.name.lower(),
+                suffix=config.register_field_read_function + "_val"
+            )
+
+            self._field_get_val(outfile, reg, field)
+
+    @shoulder.gadget.c.function_definition
+    def _field_get_val(self, outfile, reg, field):
+        f_body = "return (val & {mask}) >> {lsb};"
+
+        f_body = f_body.format(
+            size=self._register_size_type(reg),
+            mask=self._field_mask_string(reg, field),
+            lsb=self._field_lsb_string(reg, field)
+        )
+
+        outfile.write(f_body)
+
+# ----------------------------------------------------------------------------
+# field_set
+# ----------------------------------------------------------------------------
+    def _generate_field_set(self, outfile, reg, field):
+        """
+        Generate a C function that writes the given field to the given register
+        """
+
+        if reg.writeable():
+            size_type = self._register_size_type(reg)
+
+            gadget = self.gadgets["shoulder.c.function_definition"]
+            gadget.return_type = size_type
+            gadget.args = [(size_type, "val")]
+            gadget.name = "{prefix}_{rname}_{fname}_{suffix}".format(
+                prefix=self._register_function_prefix(reg),
+                rname=reg.name.lower(),
+                fname=field.name.lower(),
+                suffix=config.register_field_write_function
+            )
+
+            self._field_set(outfile, reg, field)
+
+    @shoulder.gadget.c.function_definition
+    def _field_set(self, outfile, reg, field):
+        f_body = "{size} reg = ({reg_get}() & ~{mask})\n"
+        f_body += "\t| ((val << {lsb}) & {mask});\n"
+        f_body += "{reg_set}(reg);"
+
+        f_body = f_body.format(
+            size=self._register_size_type(reg),
+            mask=self._field_mask_string(reg, field),
+            lsb=self._field_lsb_string(reg, field),
+            reg_get=self._register_read_function_name(reg),
+            reg_set=self._register_write_function_name(reg)
+        )
+
+        outfile.write(f_body)
+
+# ----------------------------------------------------------------------------
+# field_set_val
+# ----------------------------------------------------------------------------
+    def _generate_field_set_val(self, outfile, reg, field):
+        """
+        Generate a C function that writes the given field to an integer value
+        """
+
+        if reg.writeable():
+            size_type = self._register_size_type(reg)
+
+            gadget = self.gadgets["shoulder.c.function_definition"]
+            gadget.return_type = size_type
+            gadget.args = [(size_type, "field_val"), (size_type, "reg_val")]
+            gadget.name = "{prefix}_{rname}_{fname}_{suffix}".format(
+                prefix=self._register_function_prefix(reg),
+                rname=reg.name.lower(),
+                fname=field.name.lower(),
+                suffix=config.register_field_write_function + "_val"
+            )
+
+            self._field_set_val(outfile, reg, field)
+
+    @shoulder.gadget.c.function_definition
+    def _field_set_val(self, outfile, reg, field):
+        f_body = "return (reg_val & ~{mask})\n\t"
+        f_body += "| ((field_val << {lsb}) & {mask});"
+
+        f_body = f_body.format(
+            size=self._register_size_type(reg),
+            mask=self._field_mask_string(reg, field),
+            lsb=self._field_lsb_string(reg, field)
+        )
+
+        outfile.write(f_body)
+
+# ----------------------------------------------------------------------------
+# utilities
+# ----------------------------------------------------------------------------
+    def _field_mask_hex_string(self, reg, field):
         mask_val = 0
-        mask = ""
-
         for i in range(field.lsb, field.msb + 1):
             mask_val |= 1 << i
 
         if reg.size == 32:
-            mask = "{0:#0{1}x}".format(mask_val, 10)
+            return "{0:#0{1}x}".format(mask_val, 10)
         else:
-            mask = "{0:#0{1}x}".format(mask_val, 18)
+            return "{0:#0{1}x}".format(mask_val, 18)
 
-        accessor = "\tinline {size_t} {c_prefix}{c_suffix}_{regname}_{fieldname}_{func}_val({size_t} {arg1}, {size_t} {arg2}) "
-        accessor += "{{ SET_BITS_BY_VALUE_FUNC({arg1}, {arg2}, {mask}, {lsb}) }}\n"
-        accessor = accessor.format(
-            size_t = "uint" + str(reg.size) + "_t",
-            c_prefix = config.c_prefix,
-            c_suffix = str(reg.size),
-            regname = str(reg.name).lower(),
-            fieldname = str(field.name).lower(),
-            func = config.register_field_write_function,
-            arg1 = str(reg.access_attributes.mnemonic).lower(),
-            arg2 = "value",
-            mask = mask,
-            lsb = field.lsb
+    def _field_mask_string(self, reg, field):
+        return "{reg}_{field}_mask".format(
+            reg=reg.name.lower(),
+            field=field.name.lower()
         )
-        outfile.write(accessor)
+
+    def _field_lsb_string(self, reg, field):
+        return "{reg}_{field}_lsb".format(
+            reg=reg.name.lower(),
+            field=field.name.lower()
+        )
+
+    def _register_size_type(self, reg):
+        if reg.size == 32:
+            return "uint32_t"
+        else:
+            return "uint64_t"
+
+    def _register_read_function_name(self, reg):
+        return "{prefix}_{reg_name}_{read}".format(
+            prefix=self._register_function_prefix(reg),
+            reg_name=reg.name.lower(),
+            read=config.register_read_function
+        )
+
+    def _register_write_function_name(self, reg):
+        return "{prefix}_{reg_name}_{write}".format(
+            prefix=self._register_function_prefix(reg),
+            reg_name=reg.name.lower(),
+            write=config.register_write_function
+        )
+
+    def _register_function_prefix(self, reg):
+        p = config.c_prefix
+        if reg.execution_state:
+            return p + str(reg.execution_state)
+        elif not reg.attributes["is_internal"]:
+            return p + "external"
+        else:
+            return p

--- a/shoulder/generator/cxx_header_generator.py
+++ b/shoulder/generator/cxx_header_generator.py
@@ -60,22 +60,13 @@ class CxxHeaderGenerator(AbstractGenerator):
         accessor macros before generating register accessors
         """
         for obj in objects:
-            if(isinstance(obj, Register)):
-                if not obj.is_sysreg: return
+            reg_name = str(obj.name).lower()
+            self.gadgets["shoulder.cxx.namespace"].name = reg_name
+            self.gadgets["shoulder.cxx.namespace"].indent = 0
 
-                reg_name = str(obj.name).lower()
-                self.gadgets["shoulder.cxx.namespace"].name = reg_name
-                self.gadgets["shoulder.cxx.namespace"].indent = 0
-
-                logger.debug("Writing register: " + reg_name)
-                self._generate_register_comment(outfile, obj)
-                self._generate_register(outfile, obj)
-
-            else:
-                msg = "Cannot generate object of unsupported {t} type".format(
-                    t = type(obj)
-                )
-                raise ShoulderGeneratorException(msg)
+            logger.debug("Writing register: " + reg_name)
+            self._generate_register_comment(outfile, obj)
+            self._generate_register(outfile, obj)
 
     @cxx.namespace
     def _generate_register(self, outfile, reg):

--- a/shoulder/model/__init__.py
+++ b/shoulder/model/__init__.py
@@ -24,4 +24,3 @@ from .register import Register
 from .fieldset import Fieldset
 from .fieldset import Field
 from .access_attributes import AccessAttributes
-from .access_mechanism import *

--- a/shoulder/model/__init__.py
+++ b/shoulder/model/__init__.py
@@ -23,4 +23,3 @@
 from .register import Register
 from .fieldset import Fieldset
 from .fieldset import Field
-from .access_attributes import AccessAttributes

--- a/shoulder/model/access_mechanism/__init__.py
+++ b/shoulder/model/access_mechanism/__init__.py
@@ -20,16 +20,16 @@
 # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 # SOFTWARE.
 
-from .read_coprocessor_register import ReadCoprocessorRegister
-from .read_coprocessor_register2 import ReadCoprocessorRegister2
-from .read_memory_mapped import ReadMemoryMapped
-from .read_system_register import ReadSystemRegister
-from .read_system_register_banked import ReadSystemRegisterBanked
-from .read_system_vector_register import ReadSystemVectorRegister
-from .write_coprocessor_register import WriteCoprocessorRegister
-from .write_coprocessor_register2 import WriteCoprocessorRegister2
-from .write_memory_mapped import WriteMemoryMapped
-from .write_system_register import WriteSystemRegister
-from .write_system_register_banked import WriteSystemRegisterBanked
-from .write_system_register_immediate import WriteSystemRegisterImmediate
-from .write_system_vector_register import WriteSystemVectorRegister
+from .ldr import LDR
+from .mcr import MCR
+from .mcrr import MCRR
+from .mrc import MRC
+from .mrrc import MRRC
+from .mrs_banked import MRSBanked
+from .mrs_register import MRSRegister
+from .msr_banked import MSRBanked
+from .msr_immediate import MSRImmediate
+from .msr_register import MSRRegister
+from .str_ import STR
+from .vmrs import VMRS
+from .vmsr import VMSR

--- a/shoulder/model/access_mechanism/ldr.py
+++ b/shoulder/model/access_mechanism/ldr.py
@@ -24,17 +24,14 @@ from shoulder.model.access_mechanism.abstract_access_mechanism import AbstractAc
 from dataclasses import dataclass
 
 @dataclass(frozen=True)
-class ReadSystemVectorRegister(AbstractAccessMechanism):
-    """ Access mechanism for reading a system vector control register """
+class LDR(AbstractAccessMechanism):
+    """ Access mechanism for reading a system control coprocessor register """
 
-    reg: bytes
-    """ ? """
-
-    operand_mnemonic: str
-    """ The operand mnemonic of the register to be accessed """
+    offset: int
+    """ Register offset """
 
     def instruction_mnemonic(self):
-        return "VMRS"
+        return "LDR"
 
     def is_read(self):
         return True

--- a/shoulder/model/access_mechanism/mcr.py
+++ b/shoulder/model/access_mechanism/mcr.py
@@ -24,20 +24,35 @@ from shoulder.model.access_mechanism.abstract_access_mechanism import AbstractAc
 from dataclasses import dataclass
 
 @dataclass(frozen=True)
-class ReadMemoryMapped(AbstractAccessMechanism):
-    """ Access mechanism for reading a system control coprocessor register """
+class MCR(AbstractAccessMechanism):
+    """ Access mechanism for writing a system control coprocessor register """
 
-    offset: int
-    """ Register offset """
+    coproc: bytes
+    """ Coprocessor number """
+
+    opc1: bytes
+    """ Coprocessor-specific opcode """
+
+    opc2: bytes
+    """ Optional coprocessor-specific opcode """
+
+    crn: bytes
+    """ Register number within the system control coprocessor """
+
+    crm: bytes
+    """ Operational register within CRn """
+
+    operand_mnemonic: str
+    """ The operand mnemonic of the register to be accessed """
 
     def instruction_mnemonic(self):
-        return "LDR"
+        return "MCR"
 
     def is_read(self):
-        return True
+        return False
 
     def is_write(self):
-        return False
+        return True
 
     def is_valid(self):
         raise NotImplementedError()

--- a/shoulder/model/access_mechanism/mcrr.py
+++ b/shoulder/model/access_mechanism/mcrr.py
@@ -24,7 +24,7 @@ from shoulder.model.access_mechanism.abstract_access_mechanism import AbstractAc
 from dataclasses import dataclass
 
 @dataclass(frozen=True)
-class WriteCoprocessorRegister2(AbstractAccessMechanism):
+class MCRR(AbstractAccessMechanism):
     """ Secondary access mechanism for writing a system control coprocessor """
     """ register """
 

--- a/shoulder/model/access_mechanism/mrc.py
+++ b/shoulder/model/access_mechanism/mrc.py
@@ -24,17 +24,29 @@ from shoulder.model.access_mechanism.abstract_access_mechanism import AbstractAc
 from dataclasses import dataclass
 
 @dataclass(frozen=True)
-class WriteSystemVectorRegister(AbstractAccessMechanism):
-    """ Access mechanism for writing a system vector control register """
+class MRC(AbstractAccessMechanism):
+    """ Access mechanism for reading a system control coprocessor register """
 
-    reg: bytes
-    """ ? """
+    coproc: bytes
+    """ Coprocessor number """
+
+    opc1: bytes
+    """ Coprocessor-specific opcode """
+
+    opc2: bytes
+    """ Optional coprocessor-specific opcode """
+
+    crn: bytes
+    """ Register number within the system control coprocessor """
+
+    crm: bytes
+    """ Operational register within CRn """
 
     operand_mnemonic: str
     """ The operand mnemonic of the register to be accessed """
 
     def instruction_mnemonic(self):
-        return "VMSR"
+        return "MRC"
 
     def is_read(self):
         return True

--- a/shoulder/model/access_mechanism/mrrc.py
+++ b/shoulder/model/access_mechanism/mrrc.py
@@ -24,7 +24,7 @@ from shoulder.model.access_mechanism.abstract_access_mechanism import AbstractAc
 from dataclasses import dataclass
 
 @dataclass(frozen=True)
-class ReadCoprocessorRegister2(AbstractAccessMechanism):
+class MRRC(AbstractAccessMechanism):
     """ Secondary access mechanism for reading a system control coprocessor """
     """ register """
 

--- a/shoulder/model/access_mechanism/mrs_banked.py
+++ b/shoulder/model/access_mechanism/mrs_banked.py
@@ -24,35 +24,29 @@ from shoulder.model.access_mechanism.abstract_access_mechanism import AbstractAc
 from dataclasses import dataclass
 
 @dataclass(frozen=True)
-class WriteCoprocessorRegister(AbstractAccessMechanism):
-    """ Access mechanism for writing a system control coprocessor register """
+class MRSBanked(AbstractAccessMechanism):
+    """ Access mechanism for reading a banked system register """
 
-    coproc: bytes
-    """ Coprocessor number """
+    m: bytes
+    """ ? """
 
-    opc1: bytes
-    """ Coprocessor-specific opcode """
+    r: bytes
+    """ ? """
 
-    opc2: bytes
-    """ Optional coprocessor-specific opcode """
-
-    crn: bytes
-    """ Register number within the system control coprocessor """
-
-    crm: bytes
-    """ Operational register within CRn """
+    m1: bytes
+    """ ? """
 
     operand_mnemonic: str
     """ The operand mnemonic of the register to be accessed """
 
     def instruction_mnemonic(self):
-        return "MCR"
+        return "MRS"
 
     def is_read(self):
-        return False
+        return True
 
     def is_write(self):
-        return True
+        return False
 
     def is_valid(self):
         raise NotImplementedError()

--- a/shoulder/model/access_mechanism/mrs_register.py
+++ b/shoulder/model/access_mechanism/mrs_register.py
@@ -24,8 +24,9 @@ from shoulder.model.access_mechanism.abstract_access_mechanism import AbstractAc
 from dataclasses import dataclass
 
 @dataclass(frozen=True)
-class WriteSystemRegister(AbstractAccessMechanism):
-    """ Access mechanism for writing a system register """
+class MRSRegister(AbstractAccessMechanism):
+    """ Access mechanism for reading the contents of a system register into """
+    """ a general purpose register via the MRS instruciton """
 
     op0: bytes
     """ Top-level encoding of the system instruction type  """
@@ -46,16 +47,16 @@ class WriteSystemRegister(AbstractAccessMechanism):
     """ The operand mnemonic of the register to be accessed """
 
     rt: bytes = 0b0
-    """ Source general purpose register (default = x0) """
+    """ Destination general purpose register (default = x0) """
 
     def instruction_mnemonic(self):
-        return "MSR"
+        return "MRS"
 
     def is_read(self):
-        return False
+        return True
 
     def is_write(self):
-        return True
+        return False
 
     def is_valid(self):
         if self.op0 > 0b11: return False
@@ -70,7 +71,7 @@ class WriteSystemRegister(AbstractAccessMechanism):
     def binary_encoded(self):
         encoding = 0b0
         header = 0b1101010100   # System register transfer instruction
-        l = 0b0                 # Direction of transfer (1 = read, 0 = write)
+        l = 0b1                 # Direction of transfer (1 = read, 0 = write)
 
         encoding |= header << 22
         encoding |= l << 21
@@ -86,7 +87,7 @@ class WriteSystemRegister(AbstractAccessMechanism):
     def __str__(self):
         msg = super().__str__()
         msg += "\n"
-        msg += "\tAssembler Mnemonic: {instruction} {operand}, x{rt};\n"
+        msg += "\tAssembler Mnemonic: {instruction} x{rt}, {operand};\n"
         msg = msg.format(
             instruction=self.instruction_mnemonic(),
             operand=self.operand_mnemonic,

--- a/shoulder/model/access_mechanism/msr_banked.py
+++ b/shoulder/model/access_mechanism/msr_banked.py
@@ -24,8 +24,8 @@ from shoulder.model.access_mechanism.abstract_access_mechanism import AbstractAc
 from dataclasses import dataclass
 
 @dataclass(frozen=True)
-class ReadSystemRegisterBanked(AbstractAccessMechanism):
-    """ Access mechanism for reading a banked system register """
+class MSRBanked(AbstractAccessMechanism):
+    """ Access mechanism for writing a banked system register """
 
     m: bytes
     """ ? """
@@ -40,13 +40,13 @@ class ReadSystemRegisterBanked(AbstractAccessMechanism):
     """ The operand mnemonic of the register to be accessed """
 
     def instruction_mnemonic(self):
-        return "MRS"
+        return "MSR"
 
     def is_read(self):
-        return True
+        return False
 
     def is_write(self):
-        return False
+        return True
 
     def is_valid(self):
         raise NotImplementedError()

--- a/shoulder/model/access_mechanism/msr_immediate.py
+++ b/shoulder/model/access_mechanism/msr_immediate.py
@@ -24,14 +24,26 @@ from shoulder.model.access_mechanism.abstract_access_mechanism import AbstractAc
 from dataclasses import dataclass
 
 @dataclass(frozen=True)
-class WriteMemoryMapped(AbstractAccessMechanism):
-    """ Access mechanism for writing a memory mapped register """
+class MSRImmediate(AbstractAccessMechanism):
+    """ Access mechanism for writing an immediate value to a system register """
 
-    offset: int
-    """ Register offset from base address """
+    crn: bytes
+    """ ? """
+
+    op0: bytes
+    """ ? """
+
+    op1: bytes
+    """ ? """
+
+    op2: bytes
+    """ ? """
+
+    operand_mnemonic: str
+    """ The operand mnemonic of the register to be accessed """
 
     def instruction_mnemonic(self):
-        return "STR"
+        return "MSR"
 
     def is_read(self):
         return False

--- a/shoulder/model/access_mechanism/msr_register.py
+++ b/shoulder/model/access_mechanism/msr_register.py
@@ -24,9 +24,9 @@ from shoulder.model.access_mechanism.abstract_access_mechanism import AbstractAc
 from dataclasses import dataclass
 
 @dataclass(frozen=True)
-class ReadSystemRegister(AbstractAccessMechanism):
-    """ Access mechanism for reading the contents of a system register into """
-    """ a general purpose register via the MRS instruciton """
+class MSRRegister(AbstractAccessMechanism):
+    """ Access mechanism for writing a system register using the contents of """
+    """ a general purpose register """
 
     op0: bytes
     """ Top-level encoding of the system instruction type  """
@@ -47,16 +47,16 @@ class ReadSystemRegister(AbstractAccessMechanism):
     """ The operand mnemonic of the register to be accessed """
 
     rt: bytes = 0b0
-    """ Destination general purpose register (default = x0) """
+    """ Source general purpose register (default = x0) """
 
     def instruction_mnemonic(self):
-        return "MRS"
+        return "MSR"
 
     def is_read(self):
-        return True
+        return False
 
     def is_write(self):
-        return False
+        return True
 
     def is_valid(self):
         if self.op0 > 0b11: return False
@@ -71,7 +71,7 @@ class ReadSystemRegister(AbstractAccessMechanism):
     def binary_encoded(self):
         encoding = 0b0
         header = 0b1101010100   # System register transfer instruction
-        l = 0b1                 # Direction of transfer (1 = read, 0 = write)
+        l = 0b0                 # Direction of transfer (1 = read, 0 = write)
 
         encoding |= header << 22
         encoding |= l << 21
@@ -87,7 +87,7 @@ class ReadSystemRegister(AbstractAccessMechanism):
     def __str__(self):
         msg = super().__str__()
         msg += "\n"
-        msg += "\tAssembler Mnemonic: {instruction} x{rt}, {operand};\n"
+        msg += "\tAssembler Mnemonic: {instruction} {operand}, x{rt};\n"
         msg = msg.format(
             instruction=self.instruction_mnemonic(),
             operand=self.operand_mnemonic,

--- a/shoulder/model/access_mechanism/str_.py
+++ b/shoulder/model/access_mechanism/str_.py
@@ -24,23 +24,14 @@ from shoulder.model.access_mechanism.abstract_access_mechanism import AbstractAc
 from dataclasses import dataclass
 
 @dataclass(frozen=True)
-class WriteSystemRegisterBanked(AbstractAccessMechanism):
-    """ Access mechanism for writing a banked system register """
+class STR(AbstractAccessMechanism):
+    """ Access mechanism for writing a memory mapped register """
 
-    m: bytes
-    """ ? """
-
-    r: bytes
-    """ ? """
-
-    m1: bytes
-    """ ? """
-
-    operand_mnemonic: str
-    """ The operand mnemonic of the register to be accessed """
+    offset: int
+    """ Register offset from base address """
 
     def instruction_mnemonic(self):
-        return "MSR"
+        return "STR"
 
     def is_read(self):
         return False

--- a/shoulder/model/access_mechanism/vmrs.py
+++ b/shoulder/model/access_mechanism/vmrs.py
@@ -24,29 +24,17 @@ from shoulder.model.access_mechanism.abstract_access_mechanism import AbstractAc
 from dataclasses import dataclass
 
 @dataclass(frozen=True)
-class ReadCoprocessorRegister(AbstractAccessMechanism):
-    """ Access mechanism for reading a system control coprocessor register """
+class VMRS(AbstractAccessMechanism):
+    """ Access mechanism for reading a system vector control register """
 
-    coproc: bytes
-    """ Coprocessor number """
-
-    opc1: bytes
-    """ Coprocessor-specific opcode """
-
-    opc2: bytes
-    """ Optional coprocessor-specific opcode """
-
-    crn: bytes
-    """ Register number within the system control coprocessor """
-
-    crm: bytes
-    """ Operational register within CRn """
+    reg: bytes
+    """ ? """
 
     operand_mnemonic: str
     """ The operand mnemonic of the register to be accessed """
 
     def instruction_mnemonic(self):
-        return "MRC"
+        return "VMRS"
 
     def is_read(self):
         return True

--- a/shoulder/model/access_mechanism/vmsr.py
+++ b/shoulder/model/access_mechanism/vmsr.py
@@ -24,26 +24,17 @@ from shoulder.model.access_mechanism.abstract_access_mechanism import AbstractAc
 from dataclasses import dataclass
 
 @dataclass(frozen=True)
-class WriteSystemRegisterImmediate(AbstractAccessMechanism):
-    """ Access mechanism for writing an immediate value to a system register """
+class VMSR(AbstractAccessMechanism):
+    """ Access mechanism for writing a system vector control register """
 
-    crn: bytes
-    """ ? """
-
-    op0: bytes
-    """ ? """
-
-    op1: bytes
-    """ ? """
-
-    op2: bytes
+    reg: bytes
     """ ? """
 
     operand_mnemonic: str
     """ The operand mnemonic of the register to be accessed """
 
     def instruction_mnemonic(self):
-        return "MSR"
+        return "VMSR"
 
     def is_read(self):
         return False

--- a/shoulder/model/register.py
+++ b/shoulder/model/register.py
@@ -28,7 +28,16 @@ class Register(object):
     def __init__(self):
         self.name = None
         self.long_name = None
-        self.access_attributes = None
+        self.purpose = None
+        self.size = None
+        self.execution_state = ""
+        self.attributes = {
+            "is_register": False,
+            "is_internal": False,
+            "is_banked": False,
+            "is_optional": False,
+            "is_stub_entry": False
+        }
         self.access_mechanisms = {
             "mrc": [],
             "mcr": [],
@@ -45,18 +54,17 @@ class Register(object):
             "vmsr": [],
             "vmrs": [],
         }
-        self.purpose = None
-        self.size = None
-        self.offset = None
-        self.is_sysreg = True
         self.fieldsets = []
-        self.is_writable = False
 
     def __str__(self):
         msg = "{name} ({long_name})\n"
-        msg += "Purpose: {purpose}\nSize: {size}\nOffset: {offset}"
-        msg += "\nSystem Register: {is_sysreg}"
-        msg = msg.format(**self.__dict__)
+        msg += "Purpose: {purpose}\nSize: {size}\n"
+        msg = msg.format(
+            name=self.name,
+            long_name=self.long_name,
+            purpose=self.purpose,
+            size=self.size
+        )
 
         for fieldset in self.fieldsets:
             msg += "\n" + str(fieldset)

--- a/shoulder/model/register.py
+++ b/shoulder/model/register.py
@@ -22,13 +22,29 @@
 
 from shoulder.logger import logger
 
+
 class Register(object):
     """ Models a register in the ARM architecture """
     def __init__(self):
         self.name = None
         self.long_name = None
         self.access_attributes = None
-        self.access_mechanisms = []
+        self.access_mechanisms = {
+            "mrc": [],
+            "mcr": [],
+            "mrrc": [],
+            "mcrr": [],
+            "ldr": [],
+            "str": [],
+            "msr": [],
+            "mrs_register": [],
+            "mrs_banked": [],
+            "msr_register": [],
+            "msr_banked": [],
+            "msr_immediate": [],
+            "vmsr": [],
+            "vmrs": [],
+        }
         self.purpose = None
         self.size = None
         self.offset = None
@@ -59,10 +75,6 @@ class Register(object):
             logger.debug("Register " + str(self.name) + " has no long name")
             return False
 
-        if self.access_attributes is None:
-            logger.debug("Register " + str(self.name) + " has no access attributes")
-            return False
-
         if self.size is None:
             logger.debug("Register " + str(self.name) + " has no size")
             return False
@@ -75,3 +87,36 @@ class Register(object):
             if not fs.is_valid(): return False
 
         return True
+
+    def readable(self):
+        readable_mechanisms = [
+            "mrs_register",
+            "mrs_banked",
+            "mrc",
+            "mrrc",
+            "vmrs",
+            "ldr"
+        ]
+
+        for key in readable_mechanisms:
+            if self.access_mechanisms[key]:
+                return True
+
+        return False
+
+    def writeable(self):
+        writeable_mechanisms = [
+            "msr_register",
+            "mcr",
+            "mcrr",
+            "msr_banked",
+            "msr_immediate",
+            "vmsr",
+            "str"
+        ]
+
+        for key in writeable_mechanisms:
+            if self.access_mechanisms[key]:
+                return True
+
+        return False

--- a/shoulder/parser/__init__.py
+++ b/shoulder/parser/__init__.py
@@ -55,4 +55,5 @@ def parse_registers(spec_path):
             for result in results:
                 regs.append(result)
 
+    logger.debug("Registers parsed: " + str(len(regs)))
     return regs

--- a/shoulder/transform/__init__.py
+++ b/shoulder/transform/__init__.py
@@ -20,14 +20,25 @@
 # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 # SOFTWARE.
 
-import os
-import sys
-import pkgutil
-from collections import OrderedDict
+import collections
 
-pkg_dir = os.path.dirname(__file__)
-for (module_loader, name, ispkg) in pkgutil.iter_modules([pkg_dir]):
-    pkgutil.importlib.import_module('.' + name, __package__)
+from .make_read_only import MakeReadOnly
+from .make_write_only import MakeWriteOnly
+from .quirks import Quirks
+from .remove_coprocessor_am import RemoveCoprocessorAM
+from .remove_implementation_defined import RemoveImplementationDefined
+from .remove_memory_mapped_am import RemoveMemoryMappedAM
+from .remove_redundant_am import RemoveRedundantAccessMechanisms
+from .remove_redundant_fields import RemoveRedundantFields
+from .remove_reserved_0 import RemoveReserved0
+from .remove_reserved_1 import RemoveReserved1
+from .remove_reserved_sign_extended import RemoveReservedSignExtended
+from .remove_system_banked_am import RemoveSystemBankedAM
+from .remove_system_immediate_am import RemoveSystemImmediateAM
+from .remove_system_register_am import RemoveSystemRegisterAM
+from .remove_system_vector_am import RemoveSystemVectorAM
+from .special_to_underscore import SpecialToUnderscore
+from .unique_fieldset_names import UniqueFieldsetNames
 
 # -----------------------------------------------------------------------------
 # Module interface
@@ -38,15 +49,26 @@ for (module_loader, name, ispkg) in pkgutil.iter_modules([pkg_dir]):
 # from shoulder.transform import transforms
 # registers = transforms["name"].transform(registers)
 
-transforms = OrderedDict()
+transforms = collections.OrderedDict()
 
-transforms["quirks"] = quirks.QuirksTransform()
-transforms["remove_implementation_defined"] = \
-    remove_implementation_defined.RemoveImplementationDefinedTransform()
-transforms["remove_reserved_0"] = remove_reserved_0.RemoveReserved0Transform()
-transforms["remove_reserved_1"] = remove_reserved_1.RemoveReserved1Transform()
-transforms["special_to_underscore"] = \
-    special_to_underscore.SpecialToUnderscoreTransform()
+transforms["make_read_only"] = MakeReadOnly()
+transforms["make_write_only"] = MakeWriteOnly()
+transforms["quirks"] = Quirks()
+transforms["remove_implementation_defined"] = RemoveImplementationDefined()
+transforms["remove_coprocessor_am"] = RemoveCoprocessorAM()
+transforms["remove_memory_mapped_am"] = RemoveMemoryMappedAM()
+transforms["remove_system_register_am"] = RemoveSystemRegisterAM()
+transforms["remove_system_banked_am"] = RemoveSystemBankedAM()
+transforms["remove_system_immediate_am"] = RemoveSystemImmediateAM()
+transforms["remove_system_vector_am"] = RemoveSystemVectorAM()
+transforms["remove_redundant_am"] = RemoveRedundantAccessMechanisms()
+transforms["remove_redundant_fields"] = RemoveRedundantFields()
+transforms["remove_reserved_0"] = RemoveReserved0()
+transforms["remove_reserved_1"] = RemoveReserved1()
+transforms["remove_reserved_sign_extended"] = RemoveReservedSignExtended()
+transforms["special_to_underscore"] = SpecialToUnderscore()
+transforms["unique_fieldset_names"] = UniqueFieldsetNames()
+
 
 def transform_all(registers):
     """ Apply all of the transforms to the given registers """

--- a/shoulder/transform/make_read_only.py
+++ b/shoulder/transform/make_read_only.py
@@ -21,36 +21,26 @@
 # SOFTWARE.
 
 from shoulder.transform.abstract_transform import AbstractTransform
-from shoulder.logger import logger
 
-class Quirks(AbstractTransform):
+
+class MakeReadOnly(AbstractTransform):
     @property
     def description(self):
-        return "fixing miscellaneous quirks from the XML specification"
+        d = "removing writeable access mechanisms"
+        return d
 
     def do_transform(self, reg):
-        if(reg.name == "FPEXC32_EL2"):
-            for fs in reg.fieldsets:
-                fs.fields = set([field for field in fs.fields if fs.fields.count(field.name) == "UFF"])
-                logger.debug("Removed overlapping field \"UFF\" from register FPEXC32_EL2")
+        writeable = [
+            "msr_register",
+            "mcr",
+            "mcrr",
+            "msr_banked",
+            "msr_immediate",
+            "vmsr",
+            "str"
+        ]
 
-        if(reg.name == "HCR_EL2"):
-            for fs in reg.fieldsets:
-                for f_idx, f in enumerate(fs.fields):
-                    if f.name == "TPC":
-                        del fs.fields[f_idx]
-                        logger.debug("Removed duplicate field \"TPC\" from register HCR_EL2")
-
-        if(reg.name == "EDECCR"):
-            for fs in reg.fieldsets:
-                for f_idx, f in enumerate(fs.fields):
-                    if f.name == "NSE":
-                        del fs.fields[f_idx]
-                        logger.debug("Removed overlapping field \"NSE\" from register EDECCR")
-
-                for f_idx, f in enumerate(fs.fields):
-                    if f.name == "SE":
-                        del fs.fields[f_idx]
-                        logger.debug("Removed overlapping field \"SE\" from register EDECCR")
+        for key in writeable:
+            reg.access_mechanisms[key] = []
 
         return reg

--- a/shoulder/transform/make_write_only.py
+++ b/shoulder/transform/make_write_only.py
@@ -21,36 +21,25 @@
 # SOFTWARE.
 
 from shoulder.transform.abstract_transform import AbstractTransform
-from shoulder.logger import logger
 
-class Quirks(AbstractTransform):
+
+class MakeWriteOnly(AbstractTransform):
     @property
     def description(self):
-        return "fixing miscellaneous quirks from the XML specification"
+        d = "removing readable access mechanisms"
+        return d
 
     def do_transform(self, reg):
-        if(reg.name == "FPEXC32_EL2"):
-            for fs in reg.fieldsets:
-                fs.fields = set([field for field in fs.fields if fs.fields.count(field.name) == "UFF"])
-                logger.debug("Removed overlapping field \"UFF\" from register FPEXC32_EL2")
+        readable = [
+            "mrs_register",
+            "mrs_banked",
+            "mrc",
+            "mrrc",
+            "vmrs",
+            "ldr"
+        ]
 
-        if(reg.name == "HCR_EL2"):
-            for fs in reg.fieldsets:
-                for f_idx, f in enumerate(fs.fields):
-                    if f.name == "TPC":
-                        del fs.fields[f_idx]
-                        logger.debug("Removed duplicate field \"TPC\" from register HCR_EL2")
-
-        if(reg.name == "EDECCR"):
-            for fs in reg.fieldsets:
-                for f_idx, f in enumerate(fs.fields):
-                    if f.name == "NSE":
-                        del fs.fields[f_idx]
-                        logger.debug("Removed overlapping field \"NSE\" from register EDECCR")
-
-                for f_idx, f in enumerate(fs.fields):
-                    if f.name == "SE":
-                        del fs.fields[f_idx]
-                        logger.debug("Removed overlapping field \"SE\" from register EDECCR")
+        for key in readable:
+            reg.access_mechanisms[key] = []
 
         return reg

--- a/shoulder/transform/remove_coprocessor_am.py
+++ b/shoulder/transform/remove_coprocessor_am.py
@@ -21,36 +21,18 @@
 # SOFTWARE.
 
 from shoulder.transform.abstract_transform import AbstractTransform
-from shoulder.logger import logger
 
-class Quirks(AbstractTransform):
+
+class RemoveCoprocessorAM(AbstractTransform):
     @property
     def description(self):
-        return "fixing miscellaneous quirks from the XML specification"
+        d = "removing coprocessor access mechanisms"
+        return d
 
     def do_transform(self, reg):
-        if(reg.name == "FPEXC32_EL2"):
-            for fs in reg.fieldsets:
-                fs.fields = set([field for field in fs.fields if fs.fields.count(field.name) == "UFF"])
-                logger.debug("Removed overlapping field \"UFF\" from register FPEXC32_EL2")
-
-        if(reg.name == "HCR_EL2"):
-            for fs in reg.fieldsets:
-                for f_idx, f in enumerate(fs.fields):
-                    if f.name == "TPC":
-                        del fs.fields[f_idx]
-                        logger.debug("Removed duplicate field \"TPC\" from register HCR_EL2")
-
-        if(reg.name == "EDECCR"):
-            for fs in reg.fieldsets:
-                for f_idx, f in enumerate(fs.fields):
-                    if f.name == "NSE":
-                        del fs.fields[f_idx]
-                        logger.debug("Removed overlapping field \"NSE\" from register EDECCR")
-
-                for f_idx, f in enumerate(fs.fields):
-                    if f.name == "SE":
-                        del fs.fields[f_idx]
-                        logger.debug("Removed overlapping field \"SE\" from register EDECCR")
+        reg.access_mechanisms["mrc"] = []
+        reg.access_mechanisms["mrrc"] = []
+        reg.access_mechanisms["mcr"] = []
+        reg.access_mechanisms["mcrr"] = []
 
         return reg

--- a/shoulder/transform/remove_implementation_defined.py
+++ b/shoulder/transform/remove_implementation_defined.py
@@ -23,7 +23,8 @@
 from shoulder.transform.abstract_transform import AbstractTransform
 from shoulder.logger import logger
 
-class RemoveImplementationDefinedTransform(AbstractTransform):
+
+class RemoveImplementationDefined(AbstractTransform):
     @property
     def description(self):
         d = "removing IMPLEMENTATION_DEFINED fields"
@@ -32,14 +33,16 @@ class RemoveImplementationDefinedTransform(AbstractTransform):
     def do_transform(self, reg):
         for fs in reg.fieldsets:
             fs_len = len(fs.fields)
-            fs.fields = [field for field in fs.fields if not "IMPLEMENTATION_DEFINED" == field.name]
+            fs.fields = [
+                field for field in fs.fields
+                if not "IMPLEMENTATION_DEFINED" == field.name]
 
             count = fs_len - len(fs.fields)
             if count:
                 logger.debug("Removed {count} field{s} from {reg}".format(
-                    count = count,
-                    reg = reg.name,
-                    s = "" if count == 1 else "s"
+                    count=count,
+                    reg=reg.name,
+                    s="" if count == 1 else "s"
                 ))
 
         return reg

--- a/shoulder/transform/remove_memory_mapped_am.py
+++ b/shoulder/transform/remove_memory_mapped_am.py
@@ -21,36 +21,16 @@
 # SOFTWARE.
 
 from shoulder.transform.abstract_transform import AbstractTransform
-from shoulder.logger import logger
 
-class Quirks(AbstractTransform):
+
+class RemoveMemoryMappedAM(AbstractTransform):
     @property
     def description(self):
-        return "fixing miscellaneous quirks from the XML specification"
+        d = "removing memory mapped access mechanisms"
+        return d
 
     def do_transform(self, reg):
-        if(reg.name == "FPEXC32_EL2"):
-            for fs in reg.fieldsets:
-                fs.fields = set([field for field in fs.fields if fs.fields.count(field.name) == "UFF"])
-                logger.debug("Removed overlapping field \"UFF\" from register FPEXC32_EL2")
-
-        if(reg.name == "HCR_EL2"):
-            for fs in reg.fieldsets:
-                for f_idx, f in enumerate(fs.fields):
-                    if f.name == "TPC":
-                        del fs.fields[f_idx]
-                        logger.debug("Removed duplicate field \"TPC\" from register HCR_EL2")
-
-        if(reg.name == "EDECCR"):
-            for fs in reg.fieldsets:
-                for f_idx, f in enumerate(fs.fields):
-                    if f.name == "NSE":
-                        del fs.fields[f_idx]
-                        logger.debug("Removed overlapping field \"NSE\" from register EDECCR")
-
-                for f_idx, f in enumerate(fs.fields):
-                    if f.name == "SE":
-                        del fs.fields[f_idx]
-                        logger.debug("Removed overlapping field \"SE\" from register EDECCR")
+        reg.access_mechanisms["ldr"] = []
+        reg.access_mechanisms["str"] = []
 
         return reg

--- a/shoulder/transform/remove_redundant_am.py
+++ b/shoulder/transform/remove_redundant_am.py
@@ -21,36 +21,16 @@
 # SOFTWARE.
 
 from shoulder.transform.abstract_transform import AbstractTransform
-from shoulder.logger import logger
 
-class Quirks(AbstractTransform):
+
+class RemoveRedundantAccessMechanisms(AbstractTransform):
     @property
     def description(self):
-        return "fixing miscellaneous quirks from the XML specification"
+        d = "removing redundant access mechanisms"
+        return d
 
     def do_transform(self, reg):
-        if(reg.name == "FPEXC32_EL2"):
-            for fs in reg.fieldsets:
-                fs.fields = set([field for field in fs.fields if fs.fields.count(field.name) == "UFF"])
-                logger.debug("Removed overlapping field \"UFF\" from register FPEXC32_EL2")
-
-        if(reg.name == "HCR_EL2"):
-            for fs in reg.fieldsets:
-                for f_idx, f in enumerate(fs.fields):
-                    if f.name == "TPC":
-                        del fs.fields[f_idx]
-                        logger.debug("Removed duplicate field \"TPC\" from register HCR_EL2")
-
-        if(reg.name == "EDECCR"):
-            for fs in reg.fieldsets:
-                for f_idx, f in enumerate(fs.fields):
-                    if f.name == "NSE":
-                        del fs.fields[f_idx]
-                        logger.debug("Removed overlapping field \"NSE\" from register EDECCR")
-
-                for f_idx, f in enumerate(fs.fields):
-                    if f.name == "SE":
-                        del fs.fields[f_idx]
-                        logger.debug("Removed overlapping field \"SE\" from register EDECCR")
+        for key, am_list in reg.access_mechanisms.items():
+            reg.access_mechanisms[key] = am_list[0]
 
         return reg

--- a/shoulder/transform/remove_redundant_fields.py
+++ b/shoulder/transform/remove_redundant_fields.py
@@ -21,36 +21,22 @@
 # SOFTWARE.
 
 from shoulder.transform.abstract_transform import AbstractTransform
-from shoulder.logger import logger
 
-class Quirks(AbstractTransform):
+
+class RemoveRedundantFields(AbstractTransform):
     @property
     def description(self):
-        return "fixing miscellaneous quirks from the XML specification"
+        d = "removing redundant fields (by name) within each field set"
+        return d
 
     def do_transform(self, reg):
-        if(reg.name == "FPEXC32_EL2"):
-            for fs in reg.fieldsets:
-                fs.fields = set([field for field in fs.fields if fs.fields.count(field.name) == "UFF"])
-                logger.debug("Removed overlapping field \"UFF\" from register FPEXC32_EL2")
+        for idx, fs in enumerate(reg.fieldsets):
+            unique_fields = {}
 
-        if(reg.name == "HCR_EL2"):
-            for fs in reg.fieldsets:
-                for f_idx, f in enumerate(fs.fields):
-                    if f.name == "TPC":
-                        del fs.fields[f_idx]
-                        logger.debug("Removed duplicate field \"TPC\" from register HCR_EL2")
+            for f in fs.fields:
+                if f.name not in unique_fields:
+                    unique_fields[f.name] = f
 
-        if(reg.name == "EDECCR"):
-            for fs in reg.fieldsets:
-                for f_idx, f in enumerate(fs.fields):
-                    if f.name == "NSE":
-                        del fs.fields[f_idx]
-                        logger.debug("Removed overlapping field \"NSE\" from register EDECCR")
-
-                for f_idx, f in enumerate(fs.fields):
-                    if f.name == "SE":
-                        del fs.fields[f_idx]
-                        logger.debug("Removed overlapping field \"SE\" from register EDECCR")
+            reg.fieldsets[idx].fields = [v for v in unique_fields.values()]
 
         return reg

--- a/shoulder/transform/remove_reserved_0.py
+++ b/shoulder/transform/remove_reserved_0.py
@@ -23,7 +23,7 @@
 from shoulder.transform.abstract_transform import AbstractTransform
 from shoulder.logger import logger
 
-class RemoveReserved0Transform(AbstractTransform):
+class RemoveReserved0(AbstractTransform):
     @property
     def description(self):
         d = "removing reserved 0 (RES0) fields"

--- a/shoulder/transform/remove_reserved_sign_extended.py
+++ b/shoulder/transform/remove_reserved_sign_extended.py
@@ -23,34 +23,23 @@
 from shoulder.transform.abstract_transform import AbstractTransform
 from shoulder.logger import logger
 
-class Quirks(AbstractTransform):
+class RemoveReservedSignExtended(AbstractTransform):
     @property
     def description(self):
-        return "fixing miscellaneous quirks from the XML specification"
+        d = "removing reserved sign extended (RESS) fields"
+        return d
 
     def do_transform(self, reg):
-        if(reg.name == "FPEXC32_EL2"):
-            for fs in reg.fieldsets:
-                fs.fields = set([field for field in fs.fields if fs.fields.count(field.name) == "UFF"])
-                logger.debug("Removed overlapping field \"UFF\" from register FPEXC32_EL2")
+        for fs in reg.fieldsets:
+            fs_len = len(fs.fields)
+            fs.fields = [field for field in fs.fields if not field.name.startswith("RESS")]
 
-        if(reg.name == "HCR_EL2"):
-            for fs in reg.fieldsets:
-                for f_idx, f in enumerate(fs.fields):
-                    if f.name == "TPC":
-                        del fs.fields[f_idx]
-                        logger.debug("Removed duplicate field \"TPC\" from register HCR_EL2")
-
-        if(reg.name == "EDECCR"):
-            for fs in reg.fieldsets:
-                for f_idx, f in enumerate(fs.fields):
-                    if f.name == "NSE":
-                        del fs.fields[f_idx]
-                        logger.debug("Removed overlapping field \"NSE\" from register EDECCR")
-
-                for f_idx, f in enumerate(fs.fields):
-                    if f.name == "SE":
-                        del fs.fields[f_idx]
-                        logger.debug("Removed overlapping field \"SE\" from register EDECCR")
+            count = fs_len - len(fs.fields)
+            if count:
+                logger.debug("Removed {count} field{s} from {reg}".format(
+                    count = count,
+                    reg = reg.name,
+                    s = "" if count == 1 else "s"
+                ))
 
         return reg

--- a/shoulder/transform/remove_system_banked_am.py
+++ b/shoulder/transform/remove_system_banked_am.py
@@ -21,36 +21,16 @@
 # SOFTWARE.
 
 from shoulder.transform.abstract_transform import AbstractTransform
-from shoulder.logger import logger
 
-class Quirks(AbstractTransform):
+
+class RemoveSystemBankedAM(AbstractTransform):
     @property
     def description(self):
-        return "fixing miscellaneous quirks from the XML specification"
+        d = "removing banked system register access mechanisms"
+        return d
 
     def do_transform(self, reg):
-        if(reg.name == "FPEXC32_EL2"):
-            for fs in reg.fieldsets:
-                fs.fields = set([field for field in fs.fields if fs.fields.count(field.name) == "UFF"])
-                logger.debug("Removed overlapping field \"UFF\" from register FPEXC32_EL2")
-
-        if(reg.name == "HCR_EL2"):
-            for fs in reg.fieldsets:
-                for f_idx, f in enumerate(fs.fields):
-                    if f.name == "TPC":
-                        del fs.fields[f_idx]
-                        logger.debug("Removed duplicate field \"TPC\" from register HCR_EL2")
-
-        if(reg.name == "EDECCR"):
-            for fs in reg.fieldsets:
-                for f_idx, f in enumerate(fs.fields):
-                    if f.name == "NSE":
-                        del fs.fields[f_idx]
-                        logger.debug("Removed overlapping field \"NSE\" from register EDECCR")
-
-                for f_idx, f in enumerate(fs.fields):
-                    if f.name == "SE":
-                        del fs.fields[f_idx]
-                        logger.debug("Removed overlapping field \"SE\" from register EDECCR")
+        reg.access_mechanisms["msr_banked"] = []
+        reg.access_mechanisms["mrs_banked"] = []
 
         return reg

--- a/shoulder/transform/remove_system_immediate_am.py
+++ b/shoulder/transform/remove_system_immediate_am.py
@@ -21,36 +21,15 @@
 # SOFTWARE.
 
 from shoulder.transform.abstract_transform import AbstractTransform
-from shoulder.logger import logger
 
-class Quirks(AbstractTransform):
+
+class RemoveSystemImmediateAM(AbstractTransform):
     @property
     def description(self):
-        return "fixing miscellaneous quirks from the XML specification"
+        d = "removing immediate system register access mechanisms"
+        return d
 
     def do_transform(self, reg):
-        if(reg.name == "FPEXC32_EL2"):
-            for fs in reg.fieldsets:
-                fs.fields = set([field for field in fs.fields if fs.fields.count(field.name) == "UFF"])
-                logger.debug("Removed overlapping field \"UFF\" from register FPEXC32_EL2")
-
-        if(reg.name == "HCR_EL2"):
-            for fs in reg.fieldsets:
-                for f_idx, f in enumerate(fs.fields):
-                    if f.name == "TPC":
-                        del fs.fields[f_idx]
-                        logger.debug("Removed duplicate field \"TPC\" from register HCR_EL2")
-
-        if(reg.name == "EDECCR"):
-            for fs in reg.fieldsets:
-                for f_idx, f in enumerate(fs.fields):
-                    if f.name == "NSE":
-                        del fs.fields[f_idx]
-                        logger.debug("Removed overlapping field \"NSE\" from register EDECCR")
-
-                for f_idx, f in enumerate(fs.fields):
-                    if f.name == "SE":
-                        del fs.fields[f_idx]
-                        logger.debug("Removed overlapping field \"SE\" from register EDECCR")
+        reg.access_mechanisms["msr_immediate"] = []
 
         return reg

--- a/shoulder/transform/remove_system_register_am.py
+++ b/shoulder/transform/remove_system_register_am.py
@@ -21,36 +21,16 @@
 # SOFTWARE.
 
 from shoulder.transform.abstract_transform import AbstractTransform
-from shoulder.logger import logger
 
-class Quirks(AbstractTransform):
+
+class RemoveSystemRegisterAM(AbstractTransform):
     @property
     def description(self):
-        return "fixing miscellaneous quirks from the XML specification"
+        d = "removing system register access mechanisms"
+        return d
 
     def do_transform(self, reg):
-        if(reg.name == "FPEXC32_EL2"):
-            for fs in reg.fieldsets:
-                fs.fields = set([field for field in fs.fields if fs.fields.count(field.name) == "UFF"])
-                logger.debug("Removed overlapping field \"UFF\" from register FPEXC32_EL2")
-
-        if(reg.name == "HCR_EL2"):
-            for fs in reg.fieldsets:
-                for f_idx, f in enumerate(fs.fields):
-                    if f.name == "TPC":
-                        del fs.fields[f_idx]
-                        logger.debug("Removed duplicate field \"TPC\" from register HCR_EL2")
-
-        if(reg.name == "EDECCR"):
-            for fs in reg.fieldsets:
-                for f_idx, f in enumerate(fs.fields):
-                    if f.name == "NSE":
-                        del fs.fields[f_idx]
-                        logger.debug("Removed overlapping field \"NSE\" from register EDECCR")
-
-                for f_idx, f in enumerate(fs.fields):
-                    if f.name == "SE":
-                        del fs.fields[f_idx]
-                        logger.debug("Removed overlapping field \"SE\" from register EDECCR")
+        reg.access_mechanisms["mrs_register"] = []
+        reg.access_mechanisms["msr_register"] = []
 
         return reg

--- a/shoulder/transform/remove_system_vector_am.py
+++ b/shoulder/transform/remove_system_vector_am.py
@@ -21,36 +21,16 @@
 # SOFTWARE.
 
 from shoulder.transform.abstract_transform import AbstractTransform
-from shoulder.logger import logger
 
-class Quirks(AbstractTransform):
+
+class RemoveSystemVectorAM(AbstractTransform):
     @property
     def description(self):
-        return "fixing miscellaneous quirks from the XML specification"
+        d = "removing system vector access mechanisms"
+        return d
 
     def do_transform(self, reg):
-        if(reg.name == "FPEXC32_EL2"):
-            for fs in reg.fieldsets:
-                fs.fields = set([field for field in fs.fields if fs.fields.count(field.name) == "UFF"])
-                logger.debug("Removed overlapping field \"UFF\" from register FPEXC32_EL2")
-
-        if(reg.name == "HCR_EL2"):
-            for fs in reg.fieldsets:
-                for f_idx, f in enumerate(fs.fields):
-                    if f.name == "TPC":
-                        del fs.fields[f_idx]
-                        logger.debug("Removed duplicate field \"TPC\" from register HCR_EL2")
-
-        if(reg.name == "EDECCR"):
-            for fs in reg.fieldsets:
-                for f_idx, f in enumerate(fs.fields):
-                    if f.name == "NSE":
-                        del fs.fields[f_idx]
-                        logger.debug("Removed overlapping field \"NSE\" from register EDECCR")
-
-                for f_idx, f in enumerate(fs.fields):
-                    if f.name == "SE":
-                        del fs.fields[f_idx]
-                        logger.debug("Removed overlapping field \"SE\" from register EDECCR")
+        reg.access_mechanisms["vmsr"] = []
+        reg.access_mechanisms["vmrs"] = []
 
         return reg

--- a/shoulder/transform/special_to_underscore.py
+++ b/shoulder/transform/special_to_underscore.py
@@ -23,7 +23,7 @@
 from shoulder.transform.abstract_transform import AbstractTransform
 from shoulder.logger import logger
 
-class SpecialToUnderscoreTransform(AbstractTransform):
+class SpecialToUnderscore(AbstractTransform):
     def __init__(self):
         self.special_chars = "!@#$%^&*()[]{};:,./<>?\|`~-=+"
 

--- a/shoulder/transform/unique_fieldset_names.py
+++ b/shoulder/transform/unique_fieldset_names.py
@@ -21,36 +21,17 @@
 # SOFTWARE.
 
 from shoulder.transform.abstract_transform import AbstractTransform
-from shoulder.logger import logger
 
-class Quirks(AbstractTransform):
+
+class UniqueFieldsetNames(AbstractTransform):
     @property
     def description(self):
-        return "fixing miscellaneous quirks from the XML specification"
+        d = "assigning unique names to fields accross all field sets"
+        return d
 
     def do_transform(self, reg):
-        if(reg.name == "FPEXC32_EL2"):
-            for fs in reg.fieldsets:
-                fs.fields = set([field for field in fs.fields if fs.fields.count(field.name) == "UFF"])
-                logger.debug("Removed overlapping field \"UFF\" from register FPEXC32_EL2")
-
-        if(reg.name == "HCR_EL2"):
-            for fs in reg.fieldsets:
-                for f_idx, f in enumerate(fs.fields):
-                    if f.name == "TPC":
-                        del fs.fields[f_idx]
-                        logger.debug("Removed duplicate field \"TPC\" from register HCR_EL2")
-
-        if(reg.name == "EDECCR"):
-            for fs in reg.fieldsets:
-                for f_idx, f in enumerate(fs.fields):
-                    if f.name == "NSE":
-                        del fs.fields[f_idx]
-                        logger.debug("Removed overlapping field \"NSE\" from register EDECCR")
-
-                for f_idx, f in enumerate(fs.fields):
-                    if f.name == "SE":
-                        del fs.fields[f_idx]
-                        logger.debug("Removed overlapping field \"SE\" from register EDECCR")
-
+        if len(reg.fieldsets) > 1:
+            for idx, fs in enumerate(reg.fieldsets):
+                for f in fs.fields:
+                    f.name = "fieldset_" + str(idx + 1) + "_" + f.name
         return reg


### PR DESCRIPTION
@JWZepf Oh boy... get ready for a lot of review!

The goal of this patch series is to transition all shoulder components (filters, transforms, and generators) to use the new AccessMechanism based models. The CxxHeaderGenerator is the only component that hasn't been completed yet. In the future, there will also be a lot of *delete* happening to the accessor macros.

You may want to clone this PR and look at the output of the new CHeaderGenerator before you try to review. It is *significantly* different, but I think it helps get us closer to supporting all access mechanisms in the spec.