### PR TITLE
Coprocessor access mechanisms

### DIFF
--- a/include/aarch32_gcc_accessor_macros.h
+++ b/include/aarch32_gcc_accessor_macros.h
@@ -1,0 +1,243 @@
+// 
+// Shoulder
+// Copyright (C) 2018 Assured Information Security, Inc.
+// 
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+// 
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+// 
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+// 
+
+// ----------------------------------------------------------------------------
+// README
+// ----------------------------------------------------------------------------
+// This file contains aarch32-gcc specific implementations for reading and
+// writing system registers via all access mechanisms supported in AArch32
+// state. An "implementation" is the body of a function that carries out
+// a read/write using a specific access mechanism, used to back generated
+// accessor functions from a Shoulder generator
+
+#ifndef SHOULDER_AARCH32_GCC_ACCESSORS_H
+#define SHOULDER_AARCH32_GCC_ACCESSORS_H
+
+// Default implementation for reading a value using an instruction encoding.
+// Assumes that the instruction encoding contains r0 as the destination register
+// for the read
+//
+// @arg instruction_encoding a 32-bit binary representation of an instruction
+//      that reads data into r0 in aarch32 state
+//
+// returns the value read through the instruction
+#ifndef SHOULDER_AARCH32_ENCODED_READ_IMPL
+#define SHOULDER_AARCH32_ENCODED_READ_IMPL(instruction_encoding)               \
+    uint32_t val;                                                              \
+    __asm__ __volatile__(                                                      \
+        ".word "#instruction_encoding"\n"                                      \
+        "mov %[v], r0\n"                                                       \
+        : [v] "=r"(val)                                                        \
+        :                                                                      \
+        : "r0"                                                                 \
+    );                                                                         \
+    return val;
+#endif
+
+// Default implementation for writing a value using an instruction encoding.
+// Assumes that the instruction encoding contains r0 as the source register
+// for the write
+//
+// @arg instruction_encoding a 32-bit binary representation of an instruction
+//      that writes data from r0 in aarch32 state
+// @arg val an integer value to be written
+#ifndef SHOULDER_AARCH32_ENCODED_WRITE_IMPL
+#define SHOULDER_AARCH32_ENCODED_WRITE_IMPL(instruction_encoding, val)         \
+    __asm__ __volatile__(                                                      \
+        "mov r0, %[v]\n"                                                       \
+        ".word "#instruction_encoding"\n"                                      \
+        :                                                                      \
+        : [v] "r"(val)                                                         \
+        : "r0"                                                                 \
+    );
+#endif
+
+// Default implementation for reading a value using the LDR instruction.
+//
+// @arg addr the address to read from
+#ifndef SHOULDER_AARCH32_LDR_IMPL
+#define SHOULDER_AARCH32_LDR_IMPL(addr)                                        \
+    uint32_t address = addr;                                                   \
+    uint32_t val = 0;                                                          \
+    __asm__ __volatile__(                                                      \
+        "ldr %[val], %[address]\n"                                             \
+        : [val] "=r"(val)                                                      \
+        : [address] "r"(address)                                               \
+    );                                                                         \
+    return val;
+#endif
+
+// Default implementation for writing a value to a coprocessor using the MCR
+// instruction.
+//
+// @arg coproc integer value (0-15) that defines the coprocessor number
+// @arg opc1 3-bit coprocessor-specific opcode
+// @arg crn coprocessor-specific subregister
+// @arg crm coprocessor-specific register
+// @arg opc2 optional 3-bit coprocessor-specific opcode
+// @arg val the value to be written
+#ifndef SHOULDER_AARCH32_MCR_IMPL
+#define SHOULDER_AARCH32_MCR_IMPL(coproc, opc1, crn, crm, opc2, val)           \
+    __asm__ __volatile__(                                                      \
+        "mcr p"#coproc", #"#opc1", %[v], c"#crn", c"#crm", #"#opc2"\n"         \
+        :                                                                      \
+        : [v] "r"(val)                                                         \
+    );
+#endif
+
+// Default implementation for writing a value to a coprocessor using the MCRR
+// instruction.
+//
+// @arg coproc integer value (0-15) that defines the coprocessor number
+// @arg opc1 3-bit coprocessor-specific opcode
+// @arg crm coprocessor-specific register
+// @arg val the value to be written
+#ifndef SHOULDER_AARCH32_MCRR_IMPL
+#define SHOULDER_AARCH32_MCRR_IMPL(coproc, opc1, crm, val)                     \
+    volatile uint32_t r1 = (uint64_t)val & 0x00000000FFFFFFFF;                 \
+    volatile uint32_t r2 = ((uint64_t)val & 0xFFFFFFFF00000000) >> 32;         \
+    __asm__ __volatile__(                                                      \
+        "mcrr p"#coproc", #"#opc1", %[v1], %[v2], c"#crm"\n"                   \
+        :                                                                      \
+        : [v1] "r"(r1), [v2] "r"(r2)                                           \
+    );
+#endif
+
+// Default implementation for reading a value from a coprocessor using the MRC
+// instruction.
+//
+// @arg coproc integer value (0-15) that defines the coprocessor number
+// @arg opc1 3-bit coprocessor-specific opcode
+// @arg crn coprocessor-specific subregister
+// @arg crm coprocessor-specific register
+// @arg opc2 optional 3-bit coprocessor-specific opcode
+//
+// returns the value read from the coprocessor
+#ifndef SHOULDER_AARCH32_MRC_IMPL
+#define SHOULDER_AARCH32_MRC_IMPL(coproc, opc1, crn, crm, opc2)                \
+    uint32_t val;                                                              \
+    __asm__ __volatile__(                                                      \
+        "mrc p"#coproc", #"#opc1", %[v], c"#crn", c"#crm", #"#opc2"\n"         \
+        : [v] "=r"(val)                                                        \
+    );                                                                         \
+    return val;
+#endif
+
+// Default implementation for reading a value from a coprocessor using the MRRC
+// instruction.
+//
+// @arg coproc integer value (0-15) that defines the coprocessor number
+// @arg opc1 3-bit coprocessor-specific opcode
+// @arg crm coprocessor-specific register
+//
+// returns the value read from the coprocessor
+#ifndef SHOULDER_AARCH32_MRRC_IMPL
+#define SHOULDER_AARCH32_MRRC_IMPL(coproc, opc1, crm)                          \
+    volatile uint32_t r1 = 0;                                                  \
+    volatile uint32_t r2 = 0;                                                  \
+    __asm__ __volatile__(                                                      \
+        "mrrc p"#coproc", #"#opc1", %[v1], %[v2], c"#crm"\n"                   \
+        : [v1] "=r"(r1), [v2] "=r"(r2)                                         \
+    );                                                                         \
+    return (uint64_t)r1 & ((uint64_t)r2 << 32);
+#endif
+
+// Default implementation for reading a value from a banked system register to a
+// general purpose register using the MRS instruction.
+//
+// @arg sysreg_mnemonic the assmbler mnemonic for the system register to be read
+//
+// returns the value read from the system register
+#ifndef SHOULDER_AARCH32_MRS_BANKED_IMPL
+#define SHOULDER_AARCH32_MRS_BANKED_IMPL(sysreg_mnemonic)                      \
+    uint32_t val;                                                              \
+    __asm__ __volatile__(                                                      \
+        "mrs %[v], "#sysreg_mnemonic"\n"                                       \
+        : [v] "=r"(val)                                                        \
+    );                                                                         \
+    return val;
+#endif
+
+// Default implementation for writing a  value to a banked system register
+// from a general purpose register using the MSR instruction.
+//
+// @arg sysreg_mnemonic the assmbler mnemonic for the system register to be
+//      written
+// @arg val the value to be written
+#ifndef SHOULDER_AARCH32_MSR_BANKED_IMPL
+#define SHOULDER_AARCH32_MSR_BANKED_IMPL(sysreg_mnemonic, val)                 \
+    __asm__ __volatile__(                                                      \
+        "msr "#sysreg_mnemonic", %[v]\n"                                       \
+        :                                                                      \
+        : [v] "r"(val)                                                         \
+    );
+#endif
+
+// Default implementation for writing a value using the STR instruction.
+//
+// @arg addr the address to write to
+// @arg val the value to be written
+#ifndef SHOULDER_AARCH32_STR_IMPL
+#define SHOULDER_AARCH32_STR_IMPL(addr, val)                                   \
+    uint32_t address = addr;                                                   \
+    uint32_t result = 0;                                                       \
+    __asm__ __volatile__(                                                      \
+        "str %[res], %[address]\n"                                             \
+        :                                                                      \
+        : [address] "r"(address), [res] "r"(result)                            \
+    );
+#endif
+
+// Default implementation for writing a value to a NEON/VFP system register
+// from a general purpose register using the VMSR instruction.
+//
+// @arg extsysreg_mnemonic the assmbler mnemonic for the NEON/VFP system
+//      register to be written
+// @arg val the value to be written
+#ifndef SHOULDER_AARCH32_VMSR_IMPL
+#define SHOULDER_AARCH32_VMSR_IMPL(extsysreg_mnemonic, val)                    \
+    __asm__ __volatile__(                                                      \
+        "vmsr "#extsysreg_mnemonic", %[v]\n"                                   \
+        :                                                                      \
+        : [v] "r"(val)                                                         \
+    );
+#endif
+
+// Default implementation for reading a value from a NEON/VFP system register
+// to a general purpose register using the VMRS instruction.
+//
+// @arg extsysreg_mnemonic the assmbler mnemonic for the NEON/VFP system
+//      register to be read
+//
+// returns the value read from the system register
+#ifndef SHOULDER_AARCH32_VMRS_IMPL
+#define SHOULDER_AARCH32_VMRS_IMPL(extsysreg_mnemonic)                         \
+    uint32_t val;                                                              \
+    __asm__ __volatile__(                                                      \
+        "vmrs %[v], "#extsysreg_mnemonic"\n"                                   \
+        : [v] "=r"(val)                                                        \
+    );                                                                         \
+    return val;
+#endif
+
+#endif

--- a/include/aarch64_gcc_accessor_macros.h
+++ b/include/aarch64_gcc_accessor_macros.h
@@ -25,24 +25,24 @@
 // README
 // ----------------------------------------------------------------------------
 // This file contains aarch64-gcc specific implementations for reading and
-// writing system registers via all access mechanisms supported in the AArch64
-// architecture. An "implementation" is the body of a function that carries out
+// writing system registers via all access mechanisms supported in AArch64
+// state. An "implementation" is the body of a function that carries out
 // a read/write using a specific access mechanism, used to back generated
 // accessor functions from a Shoulder generator
 
 #ifndef SHOULDER_AARCH64_GCC_ACCESSORS_H
 #define SHOULDER_AARCH64_GCC_ACCESSORS_H
 
-// Default implementation for reading a value using an instruction encoding.
-// Assumes that the instruction encoding contains r0 as the destination register
-// for the read
+// Default implementation for reading a value using an instruction encoding from
+// aarch64 state. Assumes that the instruction encoding contains x0 as the
+// destination register for the read
 //
 // @arg instruction_encoding a 32-bit binary representation of an instruction
-//      that reads data into r0
+//      that reads data into x0 in aarch64 state
 //
 // returns the value read through the instruction
-#ifndef SHOULDER_ENCODED_READ_IMPL
-#define SHOULDER_ENCODED_READ_IMPL(instruction_encoding)                       \
+#ifndef SHOULDER_AARCH64_ENCODED_READ_IMPL
+#define SHOULDER_AARCH64_ENCODED_READ_IMPL(instruction_encoding)               \
     uint64_t val;                                                              \
     __asm__ __volatile__(                                                      \
         ".word "#instruction_encoding"\n"                                      \
@@ -54,15 +54,15 @@
     return val;
 #endif
 
-// Default implementation for writing a value using an instruction encoding.
-// Assumes that the instruction encoding contains r0 as the source register
-// for the write
+// Default implementation for writing a value using an instruction encoding from
+// aarch64 state. Assumes that the instruction encoding contains x0 as the
+// source register for the write
 //
 // @arg instruction_encoding a 32-bit binary representation of an instruction
-//      that writes data from r0
+//      that writes data from x0 in aarch64 state
 // @arg val an integer value to be written
-#ifndef SHOULDER_ENCODED_WRITE_IMPL
-#define SHOULDER_ENCODED_WRITE_IMPL(instruction_encoding, val)                 \
+#ifndef SHOULDER_AARCH64_ENCODED_WRITE_IMPL
+#define SHOULDER_AARCH64_ENCODED_WRITE_IMPL(instruction_encoding, val)         \
     __asm__ __volatile__(                                                      \
         "mov x0, %[v]\n"                                                       \
         ".word "#instruction_encoding"\n"                                      \
@@ -75,83 +75,16 @@
 // Default implementation for reading a value using the LDR instruction.
 //
 // @arg addr the address to read from
-#ifndef SHOULDER_LDR_IMPL
-#define SHOULDER_LDR_IMPL(addr)                                                \
-    "TODO: LDR using assembler mnemonics"
-#endif
-
-// Default implementation for writing a value to a coprocessor using the MCR
-// instruction.
-//
-// @arg coproc integer value (0-15) that defines the coprocessor number
-// @arg opc1 3-bit coprocessor-specific opcode
-// @arg crn coprocessor-specific subregister
-// @arg crm coprocessor-specific register
-// @arg opc2 optional 3-bit coprocessor-specific opcode
-// @arg val the value to be written
-#ifndef SHOULDER_MCR_IMPL
-#define SHOULDER_MCR_IMPL(coproc, opc1, crn, crm, opc2, val)                   \
+#ifndef SHOULDER_AARCH64_LDR_IMPL
+#define SHOULDER_AARCH64_LDR_IMPL(addr)                                        \
+    uint64_t address = addr;                                                   \
+    uint64_t val = 0;                                                          \
     __asm__ __volatile__(                                                      \
-        "mcr p"#coproc", #"#opc1", %[v], c"#crn", c"#crm", #"#opc2"\n"         \
-        :                                                                      \
-        : [v] "r"(val)                                                         \
-    );
-#endif
-
-// Default implementation for writing a value to a coprocessor using the MCRR
-// instruction.
-//
-// @arg coproc integer value (0-15) that defines the coprocessor number
-// @arg opc1 3-bit coprocessor-specific opcode
-// @arg crm coprocessor-specific register
-// @arg val the value to be written
-#ifndef SHOULDER_MCRR_IMPL
-#define SHOULDER_MCRR_IMPL(coproc, opc1, crm, val)                             \
-    "TODO: MCRR using assembler mnemonics"
-#endif
-
-// Default implementation for reading a value from a coprocessor using the MRC
-// instruction.
-//
-// @arg coproc integer value (0-15) that defines the coprocessor number
-// @arg opc1 3-bit coprocessor-specific opcode
-// @arg crn coprocessor-specific subregister
-// @arg crm coprocessor-specific register
-// @arg opc2 optional 3-bit coprocessor-specific opcode
-//
-// returns the value read from the coprocessor
-#ifndef SHOULDER_MRC_IMPL
-#define SHOULDER_MRC_IMPL(coproc, opc1, crn, crm, opc2)                        \
-    uint32_t val;                                                              \
-    __asm__ __volatile__(                                                      \
-        "mrc p"#coproc", #"#opc1", %[v], c"#crn", c"#crm", #"#opc2"\n"         \
-        : [v] "=r"(val)                                                        \
+        "ldr %[val], %[address]\n"                                             \
+        : [val] "=r"(val)                                                      \
+        : [address] "r"(address)                                               \
     );                                                                         \
     return val;
-#endif
-
-// Default implementation for reading a value from a coprocessor using the MRRC
-// instruction.
-//
-// @arg coproc integer value (0-15) that defines the coprocessor number
-// @arg opc1 3-bit coprocessor-specific opcode
-// @arg crm coprocessor-specific register
-//
-// returns the value read from the coprocessor
-#ifndef SHOULDER_MRRC_IMPL
-#define SHOULDER_MRRC_IMPL(coproc, opc1, crm)                                  \
-    "TODO: MRRC using assembler mnemonics"
-#endif
-
-// Default implementation for reading a value from a banked system register to a
-// general purpose register using the MRS instruction.
-//
-// @arg sysreg_mnemonic the assmbler mnemonic for the system register to be read
-//
-// returns the value read from the system register
-#ifndef SHOULDER_MRS_BANKED_IMPL
-#define SHOULDER_MRS_BANKED_IMPL(sysreg_mnemonic)                              \
-    "TODO: MRS_BANKED using assembler mnemonics"
 #endif
 
 // Default implementation for reading a value from a system register to a
@@ -160,8 +93,8 @@
 // @arg sysreg_mnemonic the assmbler mnemonic for the system register to be read
 //
 // returns the value read from the system register
-#ifndef SHOULDER_MRS_REGISTER_IMPL
-#define SHOULDER_MRS_REGISTER_IMPL(sysreg_mnemonic)                            \
+#ifndef SHOULDER_AARCH64_MRS_REGISTER_IMPL
+#define SHOULDER_AARCH64_MRS_REGISTER_IMPL(sysreg_mnemonic)                    \
     uint64_t val;                                                              \
     __asm__ __volatile__(                                                      \
         "mrs %[v], "#sysreg_mnemonic"\n"                                       \
@@ -170,26 +103,19 @@
     return val;
 #endif
 
-// Default implementation for writing a  value to a banked system register
-// from a general purpose register using the MSR instruction.
-//
-// @arg sysreg_mnemonic the assmbler mnemonic for the system register to be
-//      written
-// @arg val the value to be written
-#ifndef SHOULDER_MSR_BANKED_IMPL
-#define SHOULDER_MSR_BANKED_IMPL(sysreg_mnemonic, val)                         \
-    "TODO: MSR_BANKED using assembler mnemonics"
-#endif
-
 // Default implementation for writing an immediate value to a system register
 // using the MSR instruction.
 //
 // @arg sysreg_mnemonic the assmbler mnemonic for the system register to be
 //      written
 // @arg val the value to be written
-#ifndef SHOULDER_MSR_IMMEDIATE_IMPL
-#define SHOULDER_MSR_IMMEDIATE_IMPL(sysreg_mnemonic, val)                      \
-    "TODO: MSR_IMMEDIATE using assembler mnemonics"
+#ifndef SHOULDER_AARCH64_MSR_IMMEDIATE_IMPL
+#define SHOULDER_AARCH64_MSR_IMMEDIATE_IMPL(sysreg_mnemonic, val)              \
+    __asm__ __volatile__(                                                      \
+        "msr "#sysreg_mnemonic", #"val"\n"                                     \
+        :                                                                      \
+        : [v] "r"(val)                                                         \
+    );
 #endif
 
 // Default implementation for writing a value to a system register from a
@@ -198,8 +124,8 @@
 // @arg sysreg_mnemonic the assmbler mnemonic for the system register to be
 //      written
 // @arg val the value to be written
-#ifndef SHOULDER_MSR_REGISTER_IMPL
-#define SHOULDER_MSR_REGISTER_IMPL(sysreg_mnemonic, val)                       \
+#ifndef SHOULDER_AARCH64_MSR_REGISTER_IMPL
+#define SHOULDER_AARCH64_MSR_REGISTER_IMPL(sysreg_mnemonic, val)               \
     __asm__ __volatile__(                                                      \
         "msr "#sysreg_mnemonic", %[v]\n"                                       \
         :                                                                      \
@@ -211,32 +137,15 @@
 //
 // @arg addr the address to write to
 // @arg val the value to be written
-#ifndef SHOULDER_STR_IMPL
-#define SHOULDER_STR_IMPL(addr, val)                                           \
-    "TODO: STR using assembler mnemonics"
-#endif
-
-// Default implementation for writing a value to a NEON/VFP system register
-// from a general purpose register using the VMSR instruction.
-//
-// @arg extsysreg_mnemonic the assmbler mnemonic for the NEON/VFP system
-//      register to be written
-// @arg val the value to be written
-#ifndef SHOULDER_VMSR_IMPL
-#define SHOULDER_VMSR_IMPL(extsysreg_mnemonic, val)                            \
-    "TODO: VMSR using assembler mnemonics"
-#endif
-
-// Default implementation for reading a value from a NEON/VFP system register
-// to a general purpose register using the VMRS instruction.
-//
-// @arg extsysreg_mnemonic the assmbler mnemonic for the NEON/VFP system
-//      register to be read
-//
-// returns the value read from the system register
-#ifndef SHOULDER_VMRS_IMPL
-#define SHOULDER_VMRS_IMPL(extsysreg_mnemonic)                                 \
-    "TODO: VMRS using assembler mnemonics"
+#ifndef SHOULDER_AARCH64_STR_IMPL
+#define SHOULDER_AARCH64_STR_IMPL(addr, val)                                   \
+    uint64_t address = addr;                                                   \
+    uint64_t result = 0;                                                       \
+    __asm__ __volatile__(                                                      \
+        "str %[res], %[address]\n"                                             \
+        :                                                                      \
+        : [address] "r"(address), [res] "r"(result)                            \
+    );
 #endif
 
 #endif

--- a/shoulder/config.py
+++ b/shoulder/config.py
@@ -228,7 +228,3 @@ config.add_configuration(c)
 c = Configuration("license_template_path", os.path.join(_scripts_dir, "license.txt"))
 c.description = "Path to license template for generated files"
 config.add_configuration(c)
-
-c = Configuration("accessor_macros_path", os.path.join(_include_dir, "aarch64_gcc_accessor_macros.h"))
-c.description = "Path to C/C++ register access macros"
-config.add_configuration(c)

--- a/shoulder/generator/__init__.py
+++ b/shoulder/generator/__init__.py
@@ -48,11 +48,12 @@ def generate_all(regs, outdir):
 
     for generator_class in all_generators:
         sub_outdir = os.path.abspath(os.path.join(outdir, generator_class.__name__))
-        if not os.path.exists(sub_outdir):
-                os.makedirs(sub_outdir)
 
-        if os.path.exists(config.accessor_macros_path):
-            shutil.copy(config.accessor_macros_path, sub_outdir)
+        if os.path.exists(sub_outdir):
+            shutil.rmtree(sub_outdir)
+
+        if os.path.exists(config.shoulder_include_dir):
+            shutil.copytree(config.shoulder_include_dir, sub_outdir)
 
         g = generator_class()
         g.generate(copy.deepcopy(regs), sub_outdir)


### PR DESCRIPTION
This pull request addresses issues #33, #34, and #35.

In the process of putting together this PR, I discovered that aarch64-gcc doesn't have a way to assemble instructions for aarch32 state (even though aarch32 state is technically a part of ARMv8-A 👎). Because of this, I separated our accessor macros into two different files: one that aarch32 gcc compilers support (technically, it covers many versions of gcc with the naming pattern ```arm-<system>-<abi>-gcc```), and another that aarch64-gcc supports. They can both be `#include`ed in `shoulder.h`, and it doesn't cause any problems while compiling with either compiler on my environment.

@JWZepf no rush on reviewing this PR, I've got a ton of other stuff to look into