### PR TITLE
External register support

### DIFF
--- a/include/aarch32_gcc_accessor_macros.h
+++ b/include/aarch32_gcc_accessor_macros.h
@@ -1,17 +1,17 @@
-// 
+//
 // Shoulder
 // Copyright (C) 2018 Assured Information Security, Inc.
-// 
+//
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the "Software"), to deal
 // in the Software without restriction, including without limitation the rights
 // to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
 // copies of the Software, and to permit persons to whom the Software is
 // furnished to do so, subject to the following conditions:
-// 
+//
 // The above copyright notice and this permission notice shall be included in
 // all copies or substantial portions of the Software.
-// 
+//
 // THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
 // IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
 // FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
@@ -19,7 +19,7 @@
 // LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 // SOFTWARE.
-// 
+//
 
 // ----------------------------------------------------------------------------
 // README
@@ -70,21 +70,6 @@
         : [v] "r"(val)                                                         \
         : "r0"                                                                 \
     );
-#endif
-
-// Default implementation for reading a value using the LDR instruction.
-//
-// @arg addr the address to read from
-#ifndef SHOULDER_AARCH32_LDR_IMPL
-#define SHOULDER_AARCH32_LDR_IMPL(addr)                                        \
-    uint32_t address = addr;                                                   \
-    uint32_t val = 0;                                                          \
-    __asm__ __volatile__(                                                      \
-        "ldr %[val], %[address]\n"                                             \
-        : [val] "=r"(val)                                                      \
-        : [address] "r"(address)                                               \
-    );                                                                         \
-    return val;
 #endif
 
 // Default implementation for writing a value to a coprocessor using the MCR
@@ -190,21 +175,6 @@
         "msr "#sysreg_mnemonic", %[v]\n"                                       \
         :                                                                      \
         : [v] "r"(val)                                                         \
-    );
-#endif
-
-// Default implementation for writing a value using the STR instruction.
-//
-// @arg addr the address to write to
-// @arg val the value to be written
-#ifndef SHOULDER_AARCH32_STR_IMPL
-#define SHOULDER_AARCH32_STR_IMPL(addr, val)                                   \
-    uint32_t address = addr;                                                   \
-    uint32_t result = 0;                                                       \
-    __asm__ __volatile__(                                                      \
-        "str %[res], %[address]\n"                                             \
-        :                                                                      \
-        : [address] "r"(address), [res] "r"(result)                            \
     );
 #endif
 

--- a/include/aarch64_gcc_accessor_macros.h
+++ b/include/aarch64_gcc_accessor_macros.h
@@ -1,17 +1,17 @@
-// 
+//
 // Shoulder
 // Copyright (C) 2018 Assured Information Security, Inc.
-// 
+//
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the "Software"), to deal
 // in the Software without restriction, including without limitation the rights
 // to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
 // copies of the Software, and to permit persons to whom the Software is
 // furnished to do so, subject to the following conditions:
-// 
+//
 // The above copyright notice and this permission notice shall be included in
 // all copies or substantial portions of the Software.
-// 
+//
 // THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
 // IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
 // FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
@@ -19,7 +19,7 @@
 // LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 // SOFTWARE.
-// 
+//
 
 // ----------------------------------------------------------------------------
 // README
@@ -72,21 +72,6 @@
     );
 #endif
 
-// Default implementation for reading a value using the LDR instruction.
-//
-// @arg addr the address to read from
-#ifndef SHOULDER_AARCH64_LDR_IMPL
-#define SHOULDER_AARCH64_LDR_IMPL(addr)                                        \
-    uint64_t address = addr;                                                   \
-    uint64_t val = 0;                                                          \
-    __asm__ __volatile__(                                                      \
-        "ldr %[val], %[address]\n"                                             \
-        : [val] "=r"(val)                                                      \
-        : [address] "r"(address)                                               \
-    );                                                                         \
-    return val;
-#endif
-
 // Default implementation for reading a value from a system register to a
 // general purpose register using the MRS instruction.
 //
@@ -130,21 +115,6 @@
         "msr "#sysreg_mnemonic", %[v]\n"                                       \
         :                                                                      \
         : [v] "r"(val)                                                         \
-    );
-#endif
-
-// Default implementation for writing a value using the STR instruction.
-//
-// @arg addr the address to write to
-// @arg val the value to be written
-#ifndef SHOULDER_AARCH64_STR_IMPL
-#define SHOULDER_AARCH64_STR_IMPL(addr, val)                                   \
-    uint64_t address = addr;                                                   \
-    uint64_t result = 0;                                                       \
-    __asm__ __volatile__(                                                      \
-        "str %[res], %[address]\n"                                             \
-        :                                                                      \
-        : [address] "r"(address), [res] "r"(result)                            \
     );
 #endif
 

--- a/shoulder/gadget/__init__.py
+++ b/shoulder/gadget/__init__.py
@@ -20,6 +20,7 @@
 # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 # SOFTWARE.
 
+from .external_component import external_component
 from .gadget_properties import GadgetProperties
 from .header_depends import header_depends
 from .include_guard import include_guard

--- a/shoulder/gadget/external_component.py
+++ b/shoulder/gadget/external_component.py
@@ -1,0 +1,65 @@
+#
+# Shoulder
+# Copyright (C) 2018 Assured Information Security, Inc.
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in all
+# copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+
+import typing
+
+from dataclasses import dataclass, field
+from shoulder.gadget.gadget_properties import GadgetProperties
+
+@dataclass
+class properties(GadgetProperties):
+    """ Properties of the external_component gadget """
+
+    gadget_name: str = "shoulder.external_component"
+    """ Name of the gadget these properties apply to """
+
+    components: typing.List[str] = field(default_factory= lambda: [])
+    """ List of unique components """
+
+def external_component(decorated):
+    """
+    A decorator gadget that generates base address variables for each unique
+    external component as well as a get() function
+
+    Usage:
+        @external_component
+        function(generator, outfile, ...):
+            outfile.write( <contents that depend on component base addresses> )
+    """
+
+    def external_component_decorator(generator, outfile, *args, **kwargs):
+        properties = generator.gadgets["shoulder.external_component"]
+
+        outfile.write("// External Component Base Addresses\n")
+
+        for component in properties.components:
+            outfile.write("static uintptr_t ")
+            outfile.write(component + "_base = 0x0;\n")
+
+        outfile.write("\n")
+
+        decorated(generator, outfile, *args, **kwargs)
+
+    return external_component_decorator
+
+
+

--- a/shoulder/generator/c_header_generator.py
+++ b/shoulder/generator/c_header_generator.py
@@ -61,6 +61,15 @@ class CHeaderGenerator(AbstractGenerator):
                 "aarch64_gcc_accessor_macros.h"
             ]
 
+            unique = []
+            for reg in regs:
+                external_mechs = reg.access_mechanisms["ldr"] + \
+                                 reg.access_mechanisms["str"]
+                for mech in external_mechs:
+                    if mech.component not in unique:
+                        unique.append(mech.component)
+            self.gadgets["shoulder.external_component"].components = unique
+
             with open(outfile_path, "w") as outfile:
                 self._generate(outfile, regs)
 
@@ -74,6 +83,7 @@ class CHeaderGenerator(AbstractGenerator):
     @shoulder.gadget.license
     @shoulder.gadget.include_guard
     @shoulder.gadget.header_depends
+    @shoulder.gadget.external_component
     def _generate(self, outfile, regs):
 
         for reg in regs:
@@ -179,6 +189,7 @@ class CHeaderGenerator(AbstractGenerator):
 
         elif reg.access_mechanisms["ldr"]:
             am = reg.access_mechanisms["ldr"][0]
+            self._generate_external_constants(outfile, reg, am)
             self._generate_ldr_get(outfile, reg, am)
 
         else:
@@ -243,8 +254,18 @@ class CHeaderGenerator(AbstractGenerator):
 
     @shoulder.gadget.c.function_definition
     def _generate_ldr_get(self, outfile, reg, am):
-        reg_getter = "SHOULDER_AARCH64_LDR_IMPL({addr})".format(
-            addr="0x0"
+        null_return = "0xffffffff"
+        if reg.size == 64:
+            null_return = "0xffffffffffffffff"
+
+        reg_getter =  "if ({base} == 0x0) return {null_ret};\n"
+        reg_getter += "return *(({ret_size} *)({base} + {prefix}_{reg}_offset));\n"
+        reg_getter = reg_getter.format(
+            base=str(am.component) + "_base",
+            null_ret=null_return,
+            ret_size=self._register_size_type(reg),
+            prefix=self._register_function_prefix(reg),
+            reg=reg.name.lower()
         )
         outfile.write(reg_getter)
 
@@ -297,6 +318,8 @@ class CHeaderGenerator(AbstractGenerator):
 
         elif reg.access_mechanisms["str"]:
             am = reg.access_mechanisms["str"][0]
+            if not reg.is_readable():
+                self._generate_external_constants(outfile, reg, am)
             self._generate_str_set(outfile, reg, am)
 
         elif reg.access_mechanisms["msr_immediate"]:
@@ -365,14 +388,40 @@ class CHeaderGenerator(AbstractGenerator):
 
     @shoulder.gadget.c.function_definition
     def _generate_str_set(self, outfile, reg, am):
-        reg_setter = "SHOULDER_AARCH64_STR_IMPL({addr}, val)".format(
-            addr="0x0"
+        null_return = "0xffffffff"
+        if reg.size == 64:
+            null_return = "0xffffffffffffffff"
+
+        reg_setter =  "if ({base} == 0x0) return {null_ret};\n"
+        reg_setter += "*(({ret_size} *)({base} + {prefix}_{reg}_offset)) = val;\n"
+        reg_setter = reg_setter.format(
+            base=str(am.component) + "_base",
+            null_ret=null_return,
+            ret_size=self._register_size_type(reg),
+            prefix=self._register_function_prefix(reg),
+            reg=reg.name.lower()
         )
         outfile.write(reg_setter)
 
 # ----------------------------------------------------------------------------
 # constants
 # ----------------------------------------------------------------------------
+
+    @shoulder.gadget.c.enum
+    def _generate_external_constants(self, outfile, reg, am):
+        """
+        Generate constants that describe the address offset of the given register
+        """
+
+        constants = "{prefix}_{reg}_offset = {offset}\n"
+        constants = constants.format(
+            prefix=self._register_function_prefix(reg),
+            reg=reg.name.lower(),
+            offset=am.offset
+        )
+
+        outfile.write(constants)
+
 
     @shoulder.gadget.c.enum
     def _generate_field_constants(self, outfile, reg, field):

--- a/shoulder/model/armv8a/access_mechanism/ldr.py
+++ b/shoulder/model/armv8a/access_mechanism/ldr.py
@@ -27,6 +27,9 @@ from dataclasses import dataclass
 class LDR(AbstractAccessMechanism):
     """ Access mechanism for reading a system control coprocessor register """
 
+    component: str
+    """ Component that the register is mapped to """
+
     offset: int
     """ Register offset """
 

--- a/shoulder/model/armv8a/access_mechanism/str_.py
+++ b/shoulder/model/armv8a/access_mechanism/str_.py
@@ -27,6 +27,9 @@ from dataclasses import dataclass
 class STR(AbstractAccessMechanism):
     """ Access mechanism for writing a memory mapped register """
 
+    component: str
+    """ Component that the register is mapped to """
+
     offset: int
     """ Register offset from base address """
 

--- a/shoulder/parser/armv8_xml_parser.py
+++ b/shoulder/parser/armv8_xml_parser.py
@@ -145,6 +145,11 @@ class ArmV8XmlParser(AbstractParser):
         reg_address_nodes = reg_node.findall("./reg_address")
         offsets = set()
         for node in reg_address_nodes:
+            component_node = node.find("./reg_component")
+            component = str(component_node.text).lower()
+            component = component.replace(" ", "_")
+            component = component.replace(".", "_")
+
             offset_node = node.find("./reg_offset/hexnumber")
             offset = int(offset_node.text, 0)
             offsets.add(offset)
@@ -159,11 +164,11 @@ class ArmV8XmlParser(AbstractParser):
             writable_types = set(["RW", "WO", "RO or RW", "IMPDEF"])
 
             if access_types & readable_types:
-                am = shoulder.model.armv8a.access_mechanism.LDR(offset)
+                am = shoulder.model.armv8a.access_mechanism.LDR(component, offset)
                 reg.access_mechanisms["ldr"].append(am)
 
             if access_types & writable_types:
-                am = shoulder.model.armv8a.access_mechanism.STR(offset)
+                am = shoulder.model.armv8a.access_mechanism.STR(component, offset)
                 reg.access_mechanisms["str"].append(am)
 
         # Instruction based access mechanisms


### PR DESCRIPTION
Framework for accessing external memory mapped registers. The component bases that are generated are originally set to 0. Whatever tool uses this header will need to set these component bases by parsing the device tree and correctly setting those base variables. If those variables are not set, it will return 0xFFFFFFFFFFFFFFFF to indicate an error in accessing that external register.